### PR TITLE
Utils for 'expanding' and 'flattening' xlsform json

### DIFF
--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -156,15 +156,15 @@ class FormPack(object):
         v2 = self.versions[vn2]
 
         def summr(v):
-            return json.dumps(v._v.get('content'),
+            return json.dumps(v.schema.get('content'),
                               indent=4,
                               sort_keys=True,
                               ).splitlines(1)
         out = []
         for line in difflib.unified_diff(summr(v1),
                                          summr(v2),
-                                         fromfile="v%d" % vn1,
-                                         tofile="v%d" % vn2,
+                                         fromfile=vn1,
+                                         tofile=vn2,
                                          n=1):
             out.append(line)
         return ''.join(out)

--- a/src/formpack/utils/array_to_xpath.py
+++ b/src/formpack/utils/array_to_xpath.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+SPACE_PADDING = {
+    u'+': u' + ',
+    u'-': u' - ',
+    u',': u', ',
+    u'=': u' = ',
+    u'>': u' > ',
+    u'<': u' < ',
+    u'<=': u' <= ',
+    u'>=': u' >= ',
+    u'!=': u' != ',
+    u'and': u' and ',
+    u'or': u' or ',
+}
+
+DEFAULT_FNS = {
+    u'$lookup': lambda x: "${%s}" % x,
+    u'$fn': lambda *args: args,
+}
+
+
+def array_to_xpath(outer_arr, fns={}):
+    flattened = array_to_xpath.array_to_flattened_array(outer_arr, fns)
+    return array_to_xpath.flattened_array_to_padded_string(flattened)
+
+
+def array_to_flattened_array(outer_arr, _fns):
+    fns = DEFAULT_FNS.copy()
+    fns.update(_fns)
+
+    def arr2x(arr):
+        if isinstance(arr, list):
+            # recurse
+            for item in arr:
+                arr2x(item)
+        elif isinstance(arr, basestring) or isinstance(arr, int) or \
+                isinstance(arr, float):
+            # parameter is string or number and can be added directly
+            out.append(arr)
+        elif isinstance(arr, dict):
+            keys = sorted(arr.keys())
+            if len(keys) > 0:
+                # parameter is object and should be expanded
+                _needs_parse = True
+            for key in keys:
+                # skip keys that begin with '#' as comments
+                if key.startswith('#'):
+                    continue
+                # handle keys that begin with '$' as transformable
+                elif key.startswith('$'):
+                    if key not in fns:
+                        raise ValueError('Transform function not found: %s'
+                                         % key)
+                    arr2x(fns[key](arr[key]))
+                else:
+                    arr2x(arr[key])
+    # a boolean to break out of the while loop
+    _needs_parse = True
+    while _needs_parse:
+        out = []
+        _needs_parse = False
+        arr2x(outer_arr)
+        # _needs_parse will be true iff an object was present and
+        # needed to be expanded
+        outer_arr = out
+    return outer_arr
+
+
+def flattened_array_to_padded_string(flattened):
+    out_string = ""
+    for n in range(0, len(flattened)):
+        p = flattened[n]
+        if p in SPACE_PADDING:
+            out_string += SPACE_PADDING[p]
+        else:
+            out_string += unicode(p)
+    return out_string
+
+array_to_xpath.array_to_flattened_array = array_to_flattened_array
+array_to_xpath.flattened_array_to_padded_string = \
+    flattened_array_to_padded_string

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -1,0 +1,135 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+from collections import OrderedDict
+import re
+
+
+def _convert_special_label_col(content, row, col_shortname, vals):
+    if 'translation' in vals:
+        translations = content['translations']
+        cur_translation = vals['translation']
+        cur_translation_index = translations.index(cur_translation)
+        _expandable_col = vals['column']
+        if _expandable_col not in row:
+            row[_expandable_col] = [None] * len(translations)
+        elif not isinstance(row[_expandable_col], list):
+            _oldval = row[_expandable_col]
+            _nti = translations.index(None)
+            row[_expandable_col] = [None] * len(translations)
+            row[_expandable_col][_nti] = _oldval
+        if col_shortname != _expandable_col:
+            row[_expandable_col][cur_translation_index] = row[col_shortname]
+            del row[col_shortname]
+
+
+def _get_translations_from_special_cols(special_cols, translations):
+    for (colname, parsedvals) in special_cols.iteritems():
+        if 'translation' in parsedvals:
+            if parsedvals['translation'] not in translations:
+                translations.append(parsedvals['translation'])
+    return translations
+
+
+def expand_content(content):
+    specials = _get_special_survey_cols(content)
+    translations = _get_translations_from_special_cols(specials,
+                      content.get('translations', []))
+
+    if len(translations) > 0:
+        content['translations'] = translations
+
+    for row in content.get('survey', []):
+        for key in ['type', 'constraint', 'relevant', 'calculation']:
+            if key in row and isinstance(row[key], basestring):
+                if key == 'type':
+                    row['type'] = _expand_type_to_dict(row['type'])
+                else:
+                    row[key] = _expand_xpath_to_list(row[key])
+        for (key, vals) in specials.iteritems():
+            if key in row:
+                _convert_special_label_col(content, row, key, vals)
+
+
+def _get_special_survey_cols(content):
+    '''This will extract information about columns in an xlsform with ':'s
+    and give the "expand_content" information for parsing these columns.
+    Examples--
+        'media::image',
+        'media::image::English',
+        'label::Français',
+        'hint::English',
+    For more examples, see tests.
+    '''
+    uniq_cols = set()
+    special = {}
+    for row in content.get('survey', []):
+        uniq_cols.update(row.keys())
+
+    for column_name in uniq_cols:
+        if ':' not in column_name:
+            continue
+        if column_name.startswith('bind:'):
+            continue
+        if column_name.startswith('body:'):
+            continue
+        mtch = re.match('^media\s*::?\s*([^:]+)\s*::?\s*([^:]+)$', column_name)
+        if mtch:
+            matched = mtch.groups()
+            media_type = matched[0]
+            special[column_name] = {
+                'coltype': 'media',
+                'column': 'media::{}'.format(media_type),
+                'media': media_type,
+                'translation': matched[1],
+            }
+            continue
+        mtch = re.match('^media\s*::?\s*([^:]+)$', column_name)
+        if mtch:
+            media_type = mtch.groups()[0]
+            special[column_name] = {
+                'coltype': 'media',
+                'column': 'media::{}'.format(media_type),
+                'media': media_type,
+            }
+            continue
+        mtch = re.match('^([^:]+)\s*::?\s*([^:]+)$', column_name)
+        if mtch:
+            matched = mtch.groups()
+            column_shortname = matched[0]
+            special[column_name] = {
+                'column': column_shortname,
+                'translation': matched[1],
+            }
+            # also add the empty column if it exists
+            if column_shortname in uniq_cols:
+                special[column_shortname] = {
+                    'column': column_shortname,
+                    'translation': None,
+                }
+            continue
+    return special
+
+
+def _expand_type_to_dict(type_str):
+    for _re in [
+                '^(select_one) (\w+)$',
+                '^(select_multiple) (\w+)$',
+               ]:
+        match = re.match(_re, type_str)
+        if match:
+            (type_, list_name) = match.groups()
+            return {type_: list_name}
+    _or_other = re.match('^select_one (\w+) or_other$', type_str)
+    if _or_other:
+        list_name = _or_other.groups()[0]
+        return {'select_one_or_other': list_name}
+    # if it does not expand, we return the original string
+    return type_str
+
+
+def _expand_xpath_to_list(xpath_string):
+    # a placeholder for a future expansion
+    return xpath_string

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from array_to_xpath import array_to_xpath
+
+TYPE_KEYS = ['select_one', 'select_multiple']
+
+
+def flatten_content(survey_content):
+    '''
+    if asset.content contains nested objects, then
+    this is where we "flatten" them so that they
+    will pass through to pyxform and to XLS exports
+    '''
+    if 'survey' in survey_content:
+        for row in survey_content['survey']:
+            _flatten_survey_row(row)
+    return survey_content
+
+
+def _stringify_type(json_qtype):
+    '''
+    {'select_one': 'xyz'} -> 'select_one xyz'
+    {'select_multiple': 'xyz'} -> 'select_mutliple xyz'
+    '''
+    if len(json_qtype.keys()) != 1:
+        raise ValueError('Type object must have exactly one key: %s' %
+                         ', '.join(TYPE_KEYS))
+    for try_key in TYPE_KEYS:
+        if try_key in json_qtype:
+            return '{} {}'.format(try_key, json_qtype[try_key])
+    if 'select_one_or_other' in json_qtype:
+        return 'select_one %s or_other' % json_qtype['select_one_or_other']
+
+
+def _flatten_survey_row(row):
+    for key in ['relevant', 'constraint']:
+        if key in row and isinstance(row[key], (list, tuple)):
+            row[key] = array_to_xpath(row[key])
+    if 'type' in row and isinstance(row['type'], dict):
+        row['type'] = _stringify_type(row['type'])

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -12,9 +12,12 @@ def flatten_content(survey_content):
     this is where we "flatten" them so that they
     will pass through to pyxform and to XLS exports
     '''
+    translations = survey_content.get('translations')
     if 'survey' in survey_content:
         for row in survey_content['survey']:
             _flatten_survey_row(row)
+            if len(translations) > 0:
+                _flatten_translated_fields(row, translations)
     return survey_content
 
 
@@ -31,6 +34,19 @@ def _stringify_type(json_qtype):
             return '{} {}'.format(try_key, json_qtype[try_key])
     if 'select_one_or_other' in json_qtype:
         return 'select_one %s or_other' % json_qtype['select_one_or_other']
+
+
+def _flatten_translated_fields(row, translations):
+    for key in row.keys():
+        val = row[key]
+        if isinstance(val, list):
+            items = val
+            del row[key]
+            for i in xrange(0, len(translations)):
+                translation = translations[i]
+                value = items[i]
+                if value is not None:
+                    row['{}::{}'.format(key, translation)] = value
 
 
 def _flatten_survey_row(row):

--- a/tests/test_array_to_xpath.py
+++ b/tests/test_array_to_xpath.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+import json
+
+from formpack.utils.array_to_xpath import array_to_xpath
+
+
+def response_not_equal(p):
+    return "${%s} != %s" % tuple(p)
+
+
+def _join(join_with_what):
+    def fn(p):
+        for n in range(len(p)-1, 0, -1):
+            p.insert(n, join_with_what)
+        return p
+    return fn
+
+
+def multiselect_question_not_sel(params):
+    (qn, val) = params
+    return [
+        "not(selected(",
+        {'$lookup': qn},
+        ",",
+        val,
+        "))",
+    ]
+
+
+_fns = {
+    u'$response_not_equal': response_not_equal,
+    u'$and': _join('and'),
+    u'$or': _join('or'),
+    u'$multiselect_question_not_selected': multiselect_question_not_sel,
+}
+
+
+def test_equiv_1():
+    inp = []
+    expected = ""
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_2():
+    inp = [u'a', u'b']
+    expected = "ab"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_3():
+    inp = [u'a', {u'something': u'b'}, u'c']
+    expected = "abc"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_4():
+    inp = [u'a', {u'something_b': u'b', u'something_c': u'c'}, u'd', [[u'e', u'f', {u'x': u'g'}]]]
+    expected = "abcdefg"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_5():
+    inp = [u'a', {u'# pound sign starts a comment': u'never added'}, u'b']
+    expected = "ab"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_6():
+    inp = [u'a', [u'(', u')']]
+    expected = "a()"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_7():
+    inp = [u'a', [u'(', [u'1', u'2', u'3'], u')']]
+    expected = "a(123)"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_8():
+    inp = [u'a', [u'(', [u'x', u'+', u'y', u',', u'z'], u')'], u'b']
+    expected = "a(x + y, z)b"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_9():
+    inp = [u'a', [u'(', [u'x', u'+', u'y', u',', u'z'], u')']]
+    expected = "a(x + y, z)"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_10():
+    inp = [{u'$lookup': u'abc'}]
+    expected = "${abc}"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_11():
+    inp = [{u'$lookup': u'abc'}]
+    expected = "${abc}"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_12():
+    inp = [{u'$response_not_equal': [u'question_a', u"'a'"]}]
+    expected = "${question_a} != 'a'"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_13():
+    inp = [{u'$and': [[{u'$lookup': u'a'}, u'=', u"'a'"], [{u'$lookup': u'b'}, u'=', u"'b'"], [{u'$lookup': u'c'}, u'=', u"'c'"]]}, u'and', {u'$or': [[{u'$lookup': u'x'}, u'=', u"'x'"], [{u'$lookup': u'y'}, u'=', u"'y'"]]}]
+    expected = "${a} = 'a' and ${b} = 'b' and ${c} = 'c' and ${x} = 'x' or ${y} = 'y'"
+    assert expected == array_to_xpath(inp, _fns)
+
+
+def test_equiv_14():
+    inp = [{u'aa__q1': [{u'$lookup': u'question_a'}, u'!=', u"'a'"]}, u'and', [u'${question_b}', u'<=', 123], u'and', [{u'$multiselect_question_not_selected': [u'question_c', u"'option_2'"]}], u'and', [{u'$lookup': u'question_d'}, u'=', u"'option_2'"]]
+    expected = "${question_a} != 'a' and ${question_b} <= 123 and not(selected(${question_c}, 'option_2')) and ${question_d} = 'option_2'"
+    assert expected == array_to_xpath(inp, _fns)

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -5,6 +5,7 @@ from __future__ import (unicode_literals, print_function,
 import json
 
 from formpack.utils.expand_content import expand_content, _get_special_survey_cols
+from formpack.utils.flatten_content import flatten_content
 
 
 def test_expand_select_one():
@@ -119,7 +120,11 @@ def test_expand_translations():
           'translations': ['English', 'Français']}
     expand_content(s1)
     assert s1 == x1
-
+    flatten_content(x1)
+    assert x1 == {'survey': [{'type': 'text',
+                              'label::English': 'OK?',
+                              'label::Français': 'OK!'}],
+                  'translations': ['English', 'Français']}
 
 def test_expand_translations2():
     s1 = {'survey': [{'type': 'text',

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -1,0 +1,148 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+import json
+
+from formpack.utils.expand_content import expand_content, _get_special_survey_cols
+
+
+def test_expand_select_one():
+    s1 = {'survey': [{'type': 'select_one dogs'}]}
+    expand_content(s1)
+    assert s1['survey'][0]['type'] == {'select_one': 'dogs'}
+
+
+def test_expand_select_multiple():
+    s1 = {'survey': [{'type': 'select_multiple dogs'}]}
+    expand_content(s1)
+    assert s1['survey'][0]['type'] == {'select_multiple': 'dogs'}
+
+
+def test_expand_media():
+    s1 = {'survey': [{'type': 'note',
+                      'media::image': 'ugh.jpg'}]}
+    expand_content(s1)
+    assert s1 == {'survey': [
+            {
+              'type': 'note',
+              'media::image': 'ugh.jpg'
+            }
+        ]}
+
+
+def test_expand_translated_media():
+    s1 = {'survey': [{'type': 'note',
+                      'media::image::English': 'eng.jpg'
+                      }]}
+    expand_content(s1)
+    assert s1 == {'survey': [
+            {'type': 'note',
+                'media::image': ['eng.jpg']
+             }
+        ],
+        'translations': ['English']}
+
+
+def test_expand_translated_media_with_no_translated():
+    s1 = {'survey': [{'type': 'note',
+                      'media::image': 'nolang.jpg',
+                      'media::image::English': 'eng.jpg',
+                      }],
+          'translations': ['English', None]}
+    expand_content(s1)
+    assert s1 == {'survey': [
+            {'type': 'note',
+                'media::image': ['eng.jpg', 'nolang.jpg']
+             }
+        ],
+        'translations': ['English', None]}
+
+
+def _s(rows):
+    return {'survey': [dict([[key, 'x']]) for key in rows]}
+
+
+def test_get_special_survey_cols():
+    special = _get_special_survey_cols(_s([
+            'type',
+            'media::image',
+            'media::image::English',
+            'label::Français',
+            'label',
+            'label::English',
+            'media::audio::chinese',
+            'label: Arabic',
+            'label :: German',
+            'label:English',
+            'hint:English',
+        ]))
+    assert sorted(special.keys()) == sorted([
+            'label',
+            'media::image',
+            'media::image::English',
+            'label::Français',
+            'label::English',
+            'media::audio::chinese',
+            'label: Arabic',
+            'label :: German',
+            'label:English',
+            'hint:English',
+        ])
+    values = [special[key] for key in sorted(special.keys())]
+    assert sorted(map(lambda x: x.get('translation'), values)
+                  ) == sorted(['English', 'English', 'English', 'English',
+                               'chinese', 'Arabic', 'German', 'Français',
+                               None, None])
+
+
+def test_not_special_cols():
+    not_special = [
+        'bind::orx:for',
+        'bind:jr:constraintMsg',
+        'bind:relevant',
+        'body::accuracyThreshold',
+        'body::accuracyTreshold',
+        'body::acuracyThreshold',
+        'body:accuracyThreshold',
+    ]
+    not_special = _get_special_survey_cols(_s(not_special))
+    assert not_special.keys() == []
+
+
+def test_expand_translations():
+    s1 = {'survey': [{'type': 'text',
+                      'label::English': 'OK?',
+                      'label::Français': 'OK!'}]}
+    x1 = {'survey': [{'type': 'text',
+                      'label': ['OK?', 'OK!']}],
+          'translations': ['English', 'Français']}
+    expand_content(s1)
+    assert s1 == x1
+
+
+def test_expand_translations2():
+    s1 = {'survey': [{'type': 'text',
+                      'label': 'NoLang',
+                      'label::English': 'EnglishLang'}],
+          'translations': [None, 'English']}
+    expand_content(s1)
+    expected = json.loads('''
+    {
+    "survey":
+        [
+            {
+             "type": "text",
+             "label": [
+                    "NoLang",
+                    "EnglishLang"
+                ]
+            }
+        ],
+    "translations": [
+        null,
+        "English"
+    ]
+    }
+    ''')
+    assert s1 == expected


### PR DESCRIPTION
* The expanded form will be easier to handle translations, xpaths consistently in the UI. (No more string parsing of column names)
* The flattened format can export directly to XLS and be a valid xlsform