### PR TITLE
Fixing some issues with aliases

### DIFF
--- a/src/formpack/errors.py
+++ b/src/formpack/errors.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+
+class TranslationError(ValueError):
+    pass

--- a/src/formpack/schema/datadef.py
+++ b/src/formpack/schema/datadef.py
@@ -90,11 +90,10 @@ class FormSection(FormDataDef):
 
 
 class FormChoice(FormDataDef):
-
     def __init__(self, name, *args, **kwargs):
         super(FormChoice, self).__init__(name, *args, **kwargs)
         self.name = name
-        self.options = {}
+        self.options = OrderedDict()
 
     @classmethod
     def all_from_json_definition(cls, definition, translation_list):
@@ -110,7 +109,7 @@ class FormChoice(FormDataDef):
                 choices = all_choices[choice_key] = cls(choice_key)
 
             option = choices.options[choice_name] = {}
-            _label = choice_definition.pop('label')
+            _label = choice_definition['label']
             if isinstance(_label, basestring):
                 _label = [_label]
             option['labels'] = OrderedDict(zip(translation_list, _label))

--- a/src/formpack/utils/__init__.py
+++ b/src/formpack/utils/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
-from .xform_tools import (formversion_pyxform,
-                          parse_xmljson_to_data,
+from .xform_tools import (parse_xmljson_to_data,
                           parse_xml_to_xmljson,
                           get_version_identifiers,
-                          normalize_data_type)  # noqa
+                          normalize_data_type,
+                          )  # noqa
 from .string import slugify, randstr, str_types  # noqa

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -19,8 +19,7 @@ def flatten_content(survey_content):
         if sheet_name in survey_content:
             for row in survey_content[sheet_name]:
                 _flatten_survey_row(row)
-                if len(translations) > 0:
-                    _flatten_translated_fields(row, translations)
+                _flatten_translated_fields(row, translations)
     _iter_through_sheet('survey')
     _iter_through_sheet('choices')
 
@@ -47,6 +46,9 @@ def _stringify_type(json_qtype):
 
 
 def _flatten_translated_fields(row, translations):
+    # a workaround to get the desired values
+    if len(translations) == 0:
+        translations = [UNTRANSLATED]
     for key in row.keys():
         val = row[key]
         if isinstance(val, list):

--- a/src/formpack/utils/replace_aliases.py
+++ b/src/formpack/utils/replace_aliases.py
@@ -61,12 +61,15 @@ for key in sorted(pyxform_select.keys(), key=lambda k: -1*len(k)):
 
 def _unpack_headers(p_aliases, fp_preferred):
     _aliases = p_aliases.copy().items()
-    return dict([
+    combined = dict([
         (key, val if (val not in fp_preferred) else fp_preferred[val])
         for (key, val) in _aliases
-    ] + [
-        (key, val) for (key, val) in fp_preferred.items()
-    ])
+    ] + fp_preferred.items())
+    # ensure that id_string points to id_string (for example)
+    combined.update(dict([
+        (val, val) for val in combined.values()
+    ]))
+    return combined
 
 formpack_preferred_settings_headers = {
     'title': 'form_title',

--- a/src/formpack/utils/replace_aliases.py
+++ b/src/formpack/utils/replace_aliases.py
@@ -21,42 +21,59 @@ TF_COLUMNS = [
 ]
 
 
-formpack_preferred_type_aliases = {
-    'select one': 'select_one',
-    'select all that apply': 'select_multiple',
-    'select one external': 'select_one_external',
-    'begin group': 'begin_group',
-    'begin  group': 'begin_group',
-    'end group': 'end_group',
-    'end  group': 'end_group',
-    'begin lgroup': 'begin_repeat',
-    'end lgroup': 'end_repeat',
-    'begin repeat': 'begin_repeat',
-    'end repeat': 'end_repeat',
-    'begin looped group': 'begin_repeat',
-    'end looped group': 'end_repeat',
-}
+def aliases_to_ordered_dict(_d):
+    '''
+    unpacks a dict-with-lists to an ordered dict with keys sorted by length
+    '''
+    arr = []
+    for (original, aliases) in _d.items():
+        arr.append((original, original))
+        for alias in aliases:
+            arr.append((alias, original,))
+    return OrderedDict(sorted(arr, key=lambda _kv: 0-len(_kv[0])))
 
-pyxform_select = deepcopy(pyxform_aliases.select)
-pyxform_select.update(formpack_preferred_type_aliases)
-pyxform_select.update({
-    'select multiple': 'select_multiple',
-    'select many': 'select_multiple',
-    'select_many': 'select_multiple',
+types = aliases_to_ordered_dict({
+    u'begin_group': [
+        u'begin group',
+        u'begin  group',
+    ],
+    u'end_group': [
+        u'end group',
+        u'end  group'
+    ],
+    u'begin_repeat': [
+        u'begin lgroup',
+        u'begin repeat',
+        u'begin looped group',
+    ],
+    u'end_repeat': [
+        u'end lgroup',
+        u'end repeat',
+        u'end looped group',
+    ],
 })
 
-_KNOWN_TYPES = QUESTION_TYPE_DICT.keys() + pyxform_select.values()
+selects = aliases_to_ordered_dict({
+    u'select_multiple': [
+        u'select all that apply',
+        u'select multiple',
+        u'select many',
+        u'select_many',
+        u'select all that apply from',
+        u'add select multiple prompt using',
+    ],
+    u'select_one_external': [
+        u'select one external',
+    ],
+    u'select_one': [
+        u'select one',
+        u'select one from',
+        u'add select one prompt using',
+        u'select1',
+    ],
+})
 
-select_aliases = OrderedDict()
-# sort select_aliases in order of string length
-for key in sorted(pyxform_select.keys(), key=lambda k: -1*len(k)):
-    val = pyxform_select[key]
-    if key in formpack_preferred_type_aliases.values():
-        select_aliases[key] = key
-        continue
-    if val in formpack_preferred_type_aliases:
-        val = formpack_preferred_type_aliases[val]
-    select_aliases[key] = val
+KNOWN_TYPES = set(QUESTION_TYPE_DICT.keys() + selects.values() + types.values())
 
 
 def _unpack_headers(p_aliases, fp_preferred):
@@ -97,11 +114,13 @@ survey_header_columns = _unpack_headers(pyxform_aliases.survey_header,
 
 
 def dealias_type(type_str, strict=False):
-    if type_str in _KNOWN_TYPES:
+    if type_str in KNOWN_TYPES:
         return type_str
-    for key in select_aliases.keys():
+    if type_str in types.keys():
+        return types[type_str]
+    for key in selects.keys():
         if type_str.startswith(key):
-            return type_str.replace(key, select_aliases[key])
+            return type_str.replace(key, selects[key])
     if strict:
         raise ValueError('unknown type {}'.format([type_str]))
 

--- a/src/formpack/utils/xform_tools.py
+++ b/src/formpack/utils/xform_tools.py
@@ -6,6 +6,7 @@ from __future__ import (unicode_literals, print_function,
 import re
 
 from pyxform.xls2json import workbook_to_json
+from .flatten_content import flatten_content
 from pyxform.builder import create_survey_element_from_dict
 from pyquery import PyQuery
 
@@ -34,7 +35,7 @@ DATA_TYPE_ALIASES = (
 
 
 def formversion_pyxform(data):
-    content = data.get('content')
+    content = flatten_content(data.get('content'))
     imported_survey_json = workbook_to_json(content)
     return create_survey_element_from_dict(imported_survey_json)
 

--- a/tests/fixtures/restaurant_profile/v3.json
+++ b/tests/fixtures/restaurant_profile/v3.json
@@ -11,14 +11,14 @@
                 "label::french": "nom du restaurant"
             },
             {
-                "required": "true",
+                "required": true,
                 "type": "geopoint",
                 "name": "location",
                 "label::english": "location",
                 "label::french": "lieu"
             },
             {
-                "type": "select one from eatery_types",
+                "type": "select_one eatery_types",
                 "name": "eatery_type",
                 "label::english": "type of eatery",
                 "label::french": "type de restaurant"
@@ -34,8 +34,8 @@
             {
                 "list_name": "eatery_types",
                 "name": "takeaway",
-                "label:english": "take-away",
-                "label:french": "avec vente à emporter"
+                "label::english": "take-away",
+                "label::french": "avec vente à emporter"
             }
         ]
     },

--- a/tests/test_fixtures_valid.py
+++ b/tests/test_fixtures_valid.py
@@ -9,12 +9,6 @@ from formpack import FormPack
 from .fixtures import build_fixture
 
 
-sanitation_report = build_fixture('sanitation_report')
-customer_satisfaction = build_fixture('customer_satisfaction')
-restaurant_profile = build_fixture('restaurant_profile')
-favcolor = build_fixture('favcolor')
-
-
 class TestFormPackFixtures(unittest.TestCase):
     maxDiff = None
 
@@ -26,7 +20,7 @@ class TestFormPackFixtures(unittest.TestCase):
         '''
         sanitation_report
         '''
-        title, schemas, submissions = sanitation_report
+        title, schemas, submissions = build_fixture('sanitation_report')
         fp = FormPack(schemas, title)
         self.assertEqual(len(fp.versions), 1)
         v0 = fp[0]
@@ -49,7 +43,7 @@ class TestFormPackFixtures(unittest.TestCase):
         '''
         customer_satisfaction
         '''
-        title, schemas, submissions = customer_satisfaction
+        title, schemas, submissions = build_fixture('customer_satisfaction')
         fp = FormPack(schemas, title)
         v0 = fp[0]
         self.assertEqual(len(fp.versions), 1)
@@ -63,7 +57,7 @@ class TestFormPackFixtures(unittest.TestCase):
         #                                 u'versions': schemas})
 
     def test_restaurant_profile(self):
-        title, schemas, submissions = restaurant_profile
+        title, schemas, submissions = build_fixture('restaurant_profile')
         fp = FormPack(schemas, title)
         self.assertEqual(len(fp.versions), 4)
         v0 = fp[0]
@@ -82,6 +76,6 @@ class TestFormPackFixtures(unittest.TestCase):
         '''
         favcolor has submissions_xml specified
         '''
-        fp = FormPack(**favcolor)
+        fp = FormPack(**build_fixture('favcolor'))
         self.assertEqual(len(fp.versions), 2)
 

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -2,6 +2,7 @@
 
 from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
+from copy import deepcopy
 
 from formpack import FormPack
 from .fixtures import build_fixture
@@ -15,6 +16,16 @@ def test_fixture_has_translations():
     title, schemas, submissions = build_fixture('restaurant_profile')
     fp = FormPack(schemas, title)
     assert len(fp[1].translations) == 2
+
+
+def test_to_dict():
+    schema = build_fixture('restaurant_profile')[1][2]
+    _copy = deepcopy(schema)
+    fp = FormPack([schema], 'title')
+    original_content = _copy['content']
+    new_content = fp[0].to_dict()['content']
+    assert new_content.pop('translations') == ['english', 'french']
+    assert original_content == new_content
 
 
 def test_to_xml():

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -3,19 +3,15 @@
 from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
-import unittest
 from formpack import FormPack
 from .fixtures import build_fixture
 
-restaurant_profile = build_fixture('restaurant_profile')
 
+def test_fixture_has_translations():
+    '''
+    restauraunt_profile@v2 has two translations
+    '''
 
-class TestSurveyParsers(unittest.TestCase):
-    def test_fixture_has_translations(self):
-        '''
-        restauraunt_profile@v2 has two translations
-        '''
-
-        title, schemas, submissions = restaurant_profile
-        fp = FormPack(schemas, title)
-        self.assertEqual(len(fp[1].translations), 2)
+    title, schemas, submissions = build_fixture('restaurant_profile')
+    fp = FormPack(schemas, title)
+    assert len(fp[1].translations) == 2

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -15,3 +15,14 @@ def test_fixture_has_translations():
     title, schemas, submissions = build_fixture('restaurant_profile')
     fp = FormPack(schemas, title)
     assert len(fp[1].translations) == 2
+
+
+def test_to_xml():
+    '''
+    at the very least, version.to_xml() does not fail
+    '''
+    title, schemas, submissions = build_fixture('restaurant_profile')
+    fp = FormPack(schemas, title)
+    for version in fp.versions.keys():
+        fp.versions[version].to_xml()
+    # TODO: test output matches what is expected

--- a/tests/test_replace_aliases.py
+++ b/tests/test_replace_aliases.py
@@ -84,6 +84,7 @@ def test_settings_get_replaced():
     _setting('set form title', 'form_title')
     _setting('set form id', 'id_string')
     _setting('form_id', 'id_string')
+    _setting('id_string', 'id_string')
     # no change
     _setting('form_title', 'form_title')
     _setting('sms_keyword', 'sms_keyword')

--- a/tests/test_submissions.py
+++ b/tests/test_submissions.py
@@ -7,20 +7,17 @@ import unittest
 from formpack import FormPack
 from .fixtures import build_fixture
 
-restaurant_profile = build_fixture('restaurant_profile')
 
+def test_submission_counts_match():
+    title, schemas, submissions = build_fixture('restaurant_profile')
+    fp = FormPack(schemas, title)
 
-class TestSubmissionsToVersions(unittest.TestCase):
-    def test_submission_counts_match(self):
-        title, schemas, submissions = restaurant_profile
-        fp = FormPack(schemas, title)
-
-        report = fp.autoreport(versions=fp.versions.keys())
-        stats = report.get_stats(submissions)
-        assert stats.submissions_count == len(submissions)
-        assert stats.submission_counts_by_version == {
-            u'rpv1': 1,
-            u'rpV2': 1,
-            u'rpV3': 2,
-            u'rpV4': 4,
-        }
+    report = fp.autoreport(versions=fp.versions.keys())
+    stats = report.get_stats(submissions)
+    assert stats.submissions_count == len(submissions)
+    assert stats.submission_counts_by_version == {
+        u'rpv1': 1,
+        u'rpV2': 1,
+        u'rpV3': 2,
+        u'rpV4': 4,
+    }


### PR DESCRIPTION
* doesn't incidentally remove `id_string` setting
* no longer dependent on a specific version of pyxform
