### PR TITLE
V 1.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ pyxform == 0.9.22
 cyordereddict==1.0.0
 PyExcelerate==0.6.7
 path.py==8.1.2
+jsonschema==2.5.1
 statistics==1.0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 begins==0.9
-lxml == 2.3.4
-pyquery == 1.2.11
-pyxform == 0.9.22
 cyordereddict==1.0.0
-PyExcelerate==0.6.7
-path.py==8.1.2
 jsonschema==2.5.1
+lxml==2.3.4
+path.py==8.1.2
+PyExcelerate==0.6.7
+pyquery==1.2.11
+pyxform==0.9.22
 statistics==1.0.3.5

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ requirements, dep_links = get_requirements('requirements.txt')
 dev_requirements, dev_dep_links = get_requirements('dev-requirements.txt')
 
 setup(name='formpack',
-      version='1.2',
+      version='1.3',
       description='Manipulation tools for kobocat forms',
       author='Alex Dorey',
       author_email='alex.dorey@kobotoolbox.org',

--- a/src/formpack/errors.py
+++ b/src/formpack/errors.py
@@ -4,3 +4,7 @@ from __future__ import unicode_literals
 
 class TranslationError(ValueError):
     pass
+
+
+class SchemaError(ValueError):
+    pass

--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -25,15 +25,16 @@ from copy import deepcopy
 class FormPack(object):
 
     # TODO: make a clear signature for __init__
-    def __init__(self, versions, title='Submissions', id_string=None,
+    def __init__(self, versions=None, title='Submissions', id_string=None,
                  default_version_id_key='__version__',
+                 strict_schema=False,
                  asset_type=None, submissions_xml=None):
 
         if not versions:
-            raise ValueError('A FormPack must contain at least one FormVersion')
+            versions = []
 
         # accept a single version, but normalize it to an iterable
-        if "content" in versions:
+        if isinstance(versions, dict):
             versions = [versions]
 
         self.versions = OrderedDict()
@@ -44,6 +45,7 @@ class FormPack(object):
         self.id_string = id_string
 
         self.title = title
+        self.strict_schema = strict_schema
 
         if len(self.title) > 31: # excel sheet name size limit
             self.title = self.title[:28] + '...'
@@ -125,9 +127,9 @@ class FormPack(object):
         replace_aliases(schema['content'], in_place=True)
         expand_content(schema['content'], in_place=True)
 
-        # TODO: make that an alternative constructor from_json_schema ?
-        # this way we could get rid of the construct accepting a json schema
-        # and pass it the choices, repeat and fieds
+        if self.strict_schema:
+            FormVersion.verify_schema_structure(schema)
+
         form_version = FormVersion(self, schema)
 
         # NB: id_string are readable string unique to the form

--- a/src/formpack/schema/datadef.py
+++ b/src/formpack/schema/datadef.py
@@ -100,16 +100,21 @@ class FormChoice(FormDataDef):
         all_choices = {}
         for choice_definition in definition:
             choice_name = choice_definition.get('name')
-            if not choice_name:
+            choice_key = choice_definition.get('list_name')
+            if not choice_name or not choice_key:
                 continue
-            choice_key = choice_definition['list_name']
-            try:
-                choices = all_choices[choice_key]
-            except KeyError:
-                choices = all_choices[choice_key] = cls(choice_key)
+
+            if choice_key not in all_choices:
+                all_choices[choice_key] = FormChoice(choice_key)
+            choices = all_choices[choice_key]
 
             option = choices.options[choice_name] = {}
-            _label = choice_definition['label']
+
+            # apparently choices dont need a label if they have an image
+            if 'label' in choice_definition:
+                _label = choice_definition['label']
+            else:
+                _label = choice_definition.get('image')
             if isinstance(_label, basestring):
                 _label = [_label]
             option['labels'] = OrderedDict(zip(translation_list, _label))

--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -90,7 +90,14 @@ class FormField(FormDataDef):
         if hierarchy_in_labels:
             path = []
             for level in self.hierarchy[1:_hierarchy_end]:
-                path.append(level.labels.get(lang) or level.name)
+                _t = level.labels.get(lang)
+                if isinstance(_t, list) and len(_t) is 1:
+                    _t = _t[0]
+                # sometimes, level.labels returns a list
+                if _t:
+                    path.append(_t)
+                else:
+                    path.append(level.name)
             return group_sep.join(path)
 
         return self.labels.get(lang, self.name)

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -1,5 +1,9 @@
 # coding: utf-8
 
+# This module might be more appropriately named "standardize_content"
+# and pass content through to formpack.utils.replace_aliases during
+# the standardization step: expand_content_in_place(...)
+
 from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
@@ -75,6 +79,12 @@ def expand_content_in_place(content):
         for (key, vals) in specials.iteritems():
             if key in row:
                 _expand_translatable_content(content, row, key, vals)
+
+    if 'settings' in content and isinstance(content['settings'], list):
+        if len(content['settings']) > 0:
+            content['settings'] = content['settings'][0]
+        else:
+            content['settings'] = {}
 
 
 def expand_content(content, in_place=False):

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -11,8 +11,11 @@ from .array_to_xpath import EXPANDABLE_FIELD_TYPES
 from ..constants import UNTRANSLATED
 
 
-def _convert_special_label_col(content, row, col_shortname,
-                               special_column_details):
+REMOVE_EMPTY_STRINGS = True
+
+
+def _expand_translatable_content(content, row, col_shortname,
+                                 special_column_details):
     _scd = special_column_details
     if 'translation' in _scd:
         translations = content['translations']
@@ -46,11 +49,15 @@ def expand_content_in_place(content):
         content['translations'] = translations
 
     for row in content.get('survey', []):
+        if 'name' in row and row['name'] == None:
+            del row['name']
         if 'type' in row:
             _type = row['type']
             if isinstance(_type, basestring):
                 row.update(_expand_type_to_dict(row['type']))
             elif isinstance(_type, dict):
+                # legacy {'select_one': 'xyz'} format might
+                # still be on kobo-prod
                 row.update({u'type': _type.keys()[0],
                             u'select_from_list_name': _type.values()[0]})
         for key in EXPANDABLE_FIELD_TYPES:
@@ -58,11 +65,16 @@ def expand_content_in_place(content):
                 row[key] = _expand_xpath_to_list(row[key])
         for (key, vals) in specials.iteritems():
             if key in row:
-                _convert_special_label_col(content, row, key, vals)
+                _expand_translatable_content(content, row, key, vals)
+
+        if REMOVE_EMPTY_STRINGS:
+            for (key, val) in row.items():
+                if val == "":
+                    del row[key]
     for row in content.get('choices', []):
         for (key, vals) in specials.iteritems():
             if key in row:
-                _convert_special_label_col(content, row, key, vals)
+                _expand_translatable_content(content, row, key, vals)
 
 
 def expand_content(content, in_place=False):
@@ -95,6 +107,11 @@ def _get_special_survey_cols(content):
     _pluck_uniq_cols('choices')
 
     for column_name in uniq_cols.keys():
+        if column_name in ['label', 'hint']:
+            special[column_name] = {
+                'column': column_name,
+                'translation': UNTRANSLATED,
+            }
         if ':' not in column_name:
             continue
         if column_name.startswith('bind:'):
@@ -145,9 +162,11 @@ def _get_special_survey_cols(content):
 
 def _expand_type_to_dict(type_str):
     for _re in [
-                '^(select_one)\s+(\w+)$',
-                '^(select_multiple)\s+(\w+)$',
-                '^(select_one_external)\s+(\w+)$',
+                '^(select_one_or_other)\s+(\S+)$',
+                '^(select_one)\s+(\S+)$',
+                '^(select_multiple_or_other)\s+(\S+)$',
+                '^(select_multiple)\s+(\S+)$',
+                '^(select_one_external)\s+(\S+)$',
                ]:
         match = re.match(_re, type_str)
         if match:
@@ -155,10 +174,11 @@ def _expand_type_to_dict(type_str):
             return {u'type': type_,
                     u'select_from_list_name': list_name}
 
-    _or_other = re.match('^select_one\s+(\w+)\s+or_other$', type_str)
+    _or_other = re.match('^(select_one|select_multiple)\s+(\w+)\s+or.other$',
+                         type_str)
     if _or_other:
-        list_name = _or_other.groups()[0]
-        return {u'type': 'select_one_or_other',
+        (select_mult, list_name) = _or_other.groups()
+        return {u'type': '{}_or_other'.format(select_mult),
                 u'select_from_list_name': list_name}
 
     # if it does not expand, we return the original string

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -21,6 +21,10 @@ def flatten_content_in_place(survey_content):
                 _flatten_translated_fields(row, translations)
     _iter_through_sheet('survey')
     _iter_through_sheet('choices')
+
+    if isinstance(survey_content.get('settings'), dict):
+        survey_content['settings'] = [survey_content['settings']]
+
     # do not list translations when only default exists
     if len(translations) == 1 and translations[0] == UNTRANSLATED:
         del survey_content['translations']
@@ -68,6 +72,8 @@ def _flatten_translated_fields(row, translations):
             for i in xrange(0, len(translations)):
                 _t = translations[i]
                 value = items[i]
+                if value is None:
+                    continue
                 if _t is UNTRANSLATED:
                     row[key] = value
                 else:
@@ -80,11 +86,15 @@ def _flatten_survey_row(row):
             row[key] = array_to_xpath(row[key])
     if 'type' in row:
         _type = row['type']
+        if isinstance(row.get('required'), bool):
+            row['required'] = 'true' if row['required'] else 'false'
         if isinstance(_type, dict):
             row['type'] = _stringify_type__depr(_type)
         elif 'select_from_list_name' in row:
             _list_name = row.pop('select_from_list_name')
             if row['type'] == 'select_one_or_other':
                 row['type'] = 'select_one {} or_other'.format(_list_name)
+            elif row['type'] == 'select_multiple_or_other':
+                row['type'] = 'select_multiple {} or_other'.format(_list_name)
             else:
                 row['type'] = '{} {}'.format(_type, _list_name)

--- a/src/formpack/utils/replace_aliases.py
+++ b/src/formpack/utils/replace_aliases.py
@@ -243,8 +243,9 @@ def replace_aliases_in_place(content, allowed_types=None):
 
     # replace settings
     settings = content.get('settings', {})
-    if isinstance(settings, list) and len(settings) > 0:
-        settings = settings[0]
+    if isinstance(settings, list):
+        raise ValueError('Cannot run replace_aliases() on content which has not'
+                         ' first been parsed through "expand_content".')
 
     if settings:
         content['settings'] = dict([

--- a/src/formpack/utils/replace_aliases.py
+++ b/src/formpack/utils/replace_aliases.py
@@ -10,7 +10,7 @@ from __future__ import (unicode_literals, print_function,
 
 import json
 from copy import deepcopy
-from collections import OrderedDict
+from collections import OrderedDict, defaultdict
 
 from pyxform import aliases as pyxform_aliases
 from pyxform.question_type_dictionary import QUESTION_TYPE_DICT
@@ -28,6 +28,10 @@ def aliases_to_ordered_dict(_d):
     arr = []
     for (original, aliases) in _d.items():
         arr.append((original, original))
+        if isinstance(aliases, bool):
+            aliases = [original]
+        elif isinstance(aliases, basestring):
+            aliases = [aliases]
         for alias in aliases:
             arr.append((alias, original,))
     return OrderedDict(sorted(arr, key=lambda _kv: 0-len(_kv[0])))
@@ -51,6 +55,12 @@ types = aliases_to_ordered_dict({
         u'end repeat',
         u'end looped group',
     ],
+    'text': ['string'],
+    'acknowledge': ['trigger'],
+    'image': ['photo'],
+    'datetime': ['dateTime'],
+    'deviceid': ['imei'],
+    'geopoint': ['gps'],
 })
 
 selects = aliases_to_ordered_dict({
@@ -73,6 +83,74 @@ selects = aliases_to_ordered_dict({
     ],
 })
 
+SELECT_TYPES = [
+    'select_one',
+    'select_multiple',
+    'select_one_external',
+]
+
+LABEL_OPTIONAL_TYPES = [
+    'start',
+    'today',
+    'end',
+    'calculate',
+    'deviceid',
+    'phone_number',
+    'simserial',
+    'begin_group',
+    'begin_repeat',
+]
+
+MAIN_TYPES = [
+    # basic entry
+    'text',
+    'integer',
+    'decimal',
+    'email',
+    'barcode',
+    # collect media
+    'video',
+    'image',
+    'audio',
+    # enter time values
+    'date',
+    'datetime',
+    'time',
+    # calculate
+    'subscriberid',
+
+    # meta values
+    'username',
+
+    # prompt to collect geo data
+    'location',
+    'gps',
+    'geopoint',
+    'geoshape',
+    'geotrace',
+
+    # no response
+    'acknowledge',
+    'note',
+]
+formpack_preferred_types = set(MAIN_TYPES + LABEL_OPTIONAL_TYPES + SELECT_TYPES)
+
+_pyxform_type_aliases = defaultdict(list)
+_formpack_type_reprs = {}
+
+for (_type, val) in QUESTION_TYPE_DICT.items():
+    _xform_repr = json.dumps(val, sort_keys=True)
+    if _type in formpack_preferred_types:
+        _formpack_type_reprs[_type] = _xform_repr
+    else:
+        _pyxform_type_aliases[_xform_repr].append(_type)
+
+formpack_type_aliases = aliases_to_ordered_dict(dict([
+        (_type, _pyxform_type_aliases[_repr])
+        for (_type, _repr) in _formpack_type_reprs.items()
+    ]))
+
+
 KNOWN_TYPES = set(QUESTION_TYPE_DICT.keys() + selects.values() + types.values())
 
 
@@ -90,6 +168,7 @@ def _unpack_headers(p_aliases, fp_preferred):
 
 formpack_preferred_settings_headers = {
     'title': 'form_title',
+    'form_id': 'id_string',
 }
 settings_header_columns = _unpack_headers(pyxform_aliases.settings_header,
                                           formpack_preferred_settings_headers)
@@ -113,11 +192,16 @@ survey_header_columns = _unpack_headers(pyxform_aliases.survey_header,
                                         formpack_preferred_survey_headers)
 
 
-def dealias_type(type_str, strict=False):
-    if type_str in KNOWN_TYPES:
-        return type_str
+def dealias_type(type_str, strict=False, allowed_types=None):
+    if allowed_types is None:
+        allowed_types = {}
+
     if type_str in types.keys():
         return types[type_str]
+    if type_str in allowed_types.keys():
+        return allowed_types[type_str]
+    if type_str in KNOWN_TYPES:
+        return type_str
     for key in selects.keys():
         if type_str.startswith(key):
             return type_str.replace(key, selects[key])
@@ -125,20 +209,23 @@ def dealias_type(type_str, strict=False):
         raise ValueError('unknown type {}'.format([type_str]))
 
 
-def replace_aliases(content, in_place=False):
+def replace_aliases(content, in_place=False, allowed_types=None):
     if in_place:
-        replace_aliases_in_place(content)
+        replace_aliases_in_place(content, allowed_types=allowed_types)
         return None
     else:
         _content = deepcopy(content)
-        replace_aliases_in_place(_content)
+        replace_aliases_in_place(_content, allowed_types=allowed_types)
         return _content
 
 
-def replace_aliases_in_place(content):
+def replace_aliases_in_place(content, allowed_types=None):
+    if allowed_types is not None:
+        allowed_types = aliases_to_ordered_dict(allowed_types)
+
     for row in content.get('survey', []):
         if row.get('type'):
-            row['type'] = dealias_type(row.get('type'), strict=True)
+            row['type'] = dealias_type(row.get('type'), strict=True, allowed_types=allowed_types)
 
         for col in TF_COLUMNS:
             if col in row:
@@ -149,6 +236,10 @@ def replace_aliases_in_place(content):
             if key in row and key != val:
                 row[val] = row[key]
                 del row[key]
+
+    for row in content.get('choices', []):
+        if 'list name' in row:
+            row['list_name'] = row.pop('list name')
 
     # replace settings
     settings = content.get('settings', {})

--- a/src/formpack/validators.py
+++ b/src/formpack/validators.py
@@ -1,0 +1,167 @@
+from jsonschema import validate
+
+SELECT_TYPES = [
+            'select_one',
+            'select_multiple',
+            'select_one_external',
+            'select_one_or_other',
+            'select_multiple_or_other',
+]
+
+LABEL_OPTIONAL_TYPES = [
+            'start',
+            'today',
+            'end',
+            'calculate',
+            'deviceid',
+            'phone_number',
+            'simserial',
+            'begin_group',
+            'begin_repeat',
+            'subscriberid',
+            # meta values
+            'username',
+
+            #reconsider:
+            'phonenumber',
+            'imei',
+]
+
+MAIN_TYPES = [
+            # basic entry
+            'text',
+            'integer',
+            'decimal',
+            'email',
+            'barcode',
+            # collect media
+            'video',
+            'image',
+            'audio',
+            # enter time values
+            'date',
+            'datetime',
+            'time',
+
+            # prompt to collect geo data
+            'location',
+            'gps',
+            'geopoint',
+            'geoshape',
+            'geotrace',
+
+            # no response
+            'acknowledge',
+            'note',
+]
+
+MAIN_SCHEMA = {
+    'properties': {
+        'type': {
+            'type': 'string',
+            'enum': MAIN_TYPES,
+        },
+        'name': {
+            'type': 'string',
+        },
+        'label': {
+            'type': ['array', 'string']
+        },
+    },
+    'required': ['type', 'name'],
+}
+
+SELECT_SCHEMA = {
+    'properties': {
+        'type': {
+            'type': 'string',
+            'enum': SELECT_TYPES,
+        },
+        'name': {
+            'type': 'string',
+        },
+        'label': {
+            'type': ['array', 'string'],
+        },
+        'select_from_list_name': {
+            'type': 'string',
+        },
+    },
+    'required': ['type', 'name', 'select_from_list_name'],
+}
+
+LABEL_OPTIONAL_SCHEMA = {
+    'properties': {
+        'type': {
+            'type': 'string',
+            'enum': LABEL_OPTIONAL_TYPES,
+        },
+        'name': {
+            'type': 'string',
+        },
+    },
+    'required': ['type', 'name'],
+}
+
+
+_ROW_SCHEMA = {
+        'type': 'object',
+        'oneOf': [
+            SELECT_SCHEMA,
+            MAIN_SCHEMA,
+            LABEL_OPTIONAL_SCHEMA,
+            {
+                'properties': {
+                    'type': {
+                        'type': 'string',
+                        'enum': [
+                            'end_group',
+                            'end_repeat',
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+
+_ALL_ROW_COLUMNS = [
+    'name',
+    'type',
+    'default',
+    'required',
+    'label',
+    'kuid',
+    'appearance',
+]
+
+_ALL_PROPS = {
+    'type': 'object',
+    'properties': dict([
+        (col, {'type': [
+            'string',
+            'boolean',
+            'array',
+            'object',
+            # null values probably should be filtered out?
+            # 'null'
+        ]})
+        for col in _ALL_ROW_COLUMNS
+    ])
+}
+
+ROW_SCHEMA = {
+    'type': 'object',
+    'allOf': [
+        _ALL_PROPS,
+        _ROW_SCHEMA,
+    ]
+}
+
+
+def validate_row(row, row_number):
+    validate(row, ROW_SCHEMA)
+
+
+def validate_content(content):
+    for (i, row) in enumerate(content['survey']):
+        validate_row(row, row_number=i)

--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -9,10 +9,13 @@ try:
 except ImportError:
     from collections import OrderedDict
 
+from .validators import validate_content
+
 from .constants import UNTRANSLATED, UNSPECIFIED_TRANSLATION
 from .submission import FormSubmission
 from .utils.xform_tools import formversion_pyxform
 from .utils import parse_xml_to_xmljson, normalize_data_type
+from .errors import SchemaError
 from .utils.flatten_content import flatten_content
 from .schema import (FormField, FormGroup, FormSection, FormChoice)
 from .errors import TranslationError
@@ -25,7 +28,8 @@ class LabelStruct(object):
 
     def __init__(self, labels=[], translations=[]):
         if len(labels) != len(translations):
-            raise TranslationError('Mismatched')
+            raise TranslationError('Mismatched labels and translations: '
+                                   '%d %d' % (len(labels), len(translations)))
         self._labels = labels
         self._translations = translations
         self._vals = dict(zip(translations, labels))
@@ -35,6 +39,13 @@ class LabelStruct(object):
 
 
 class FormVersion(object):
+    @classmethod
+    def verify_schema_structure(cls, struct):
+        if 'content' not in struct:
+            raise SchemaError('version content must have "content"')
+        if 'survey' not in struct['content']:
+            raise SchemaError('version content must have "survey"')
+        validate_content(struct['content'])
 
     # QUESTION FOR ALEX: get rid off _root_node_name ? What is it for ?
     def __init__(self, form_pack, schema):
@@ -47,7 +58,7 @@ class FormVersion(object):
         self.form_pack = form_pack
 
         # slug of title
-        self._root_node_name = form_pack.title
+        self.root_node_name = schema.get('root_node_name', 'data')
 
         # form version id, unique to this version of the form
         self.id = schema.get('version')
@@ -267,10 +278,11 @@ class FormVersion(object):
 
         if title is None:
             raise ValueError('cannot create xml on a survey with no title.')
+
         survey.update({
             'name': self.lookup('root_node_name', 'data'),
             'id_string': self.lookup('id_string'),
             'title': self.lookup('title'),
-            'version': self.lookup('id_string'),
+            'version': self.lookup('id'),
         })
-        return survey.to_xml().encode('utf-8')
+        return survey._to_pretty_xml().encode('utf-8')

--- a/tests/fixtures/restaurant_profile/v3.json
+++ b/tests/fixtures/restaurant_profile/v3.json
@@ -11,7 +11,7 @@
                 "label::french": "nom du restaurant"
             },
             {
-                "required": true,
+                "required": "true",
                 "type": "geopoint",
                 "name": "location",
                 "label::english": "location",

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -19,6 +19,20 @@ def test_expand_select_one():
     assert s1['survey'][0]['select_from_list_name'] == 'dogs'
 
 
+def test_expand_select_multiple_or_other():
+    s1 = {'survey': [{'type': 'select_multiple dogs or_other'}]}
+    expand_content(s1, in_place=True)
+    assert s1['survey'][0]['type'] == 'select_multiple_or_other'
+    assert s1['survey'][0]['select_from_list_name'] == 'dogs'
+
+
+def test_expand_select_one_or_other():
+    s1 = {'survey': [{'type': 'select_one dogs or_other'}]}
+    expand_content(s1, in_place=True)
+    assert s1['survey'][0]['type'] == 'select_one_or_other'
+    assert s1['survey'][0]['select_from_list_name'] == 'dogs'
+
+
 def test_expand_select_multiple():
     s1 = {'survey': [{'type': 'select_multiple dogs'}]}
     expand_content(s1, in_place=True)
@@ -139,6 +153,29 @@ def test_expand_translated_choice_sheets():
                                'label': ['En N', 'Fr N'],
                                }],
                   'translations': ['En', 'Fr']}
+
+
+def test_expand_hints_and_labels():
+    '''
+    this was an edge case that triggered some weird behavior
+    '''
+    s1 = {'survey': [{'type': 'select_one yn',
+                      'label': 'null lang select1',
+                      }],
+          'choices': [{'list_name': 'yn',
+                       'name': 'y',
+                       'label': 'y',
+                       'hint::En': 'En Y',
+                      },
+                      {
+                       'list_name': 'yn',
+                       'name': 'n',
+                       'label': 'n',
+                       'hint::En': 'En N',
+                      }],
+          }
+    expand_content(s1, in_place=True)
+    assert sorted(s1['translations']) == [None, 'En']
 
 
 def _s(rows):

--- a/tests/test_replace_aliases.py
+++ b/tests/test_replace_aliases.py
@@ -75,7 +75,7 @@ def test_select_one_external_replaced():
 def _setting(settings_key, expected):
     _s = {}
     _s[settings_key] = 'value'
-    _o = {'survey': [], 'settings': [_s]}
+    _o = {'survey': [], 'settings': _s}
     replace_aliases(_o, in_place=True)
     assert len(_o['settings'].keys()) == 1
     assert _o['settings'].keys()[0] == expected

--- a/tests/test_replace_aliases.py
+++ b/tests/test_replace_aliases.py
@@ -55,6 +55,8 @@ def test_misc_types():
     assert dealias_type('end_group') == 'end_group'
     assert dealias_type('begin_repeat') == 'begin_repeat'
     assert dealias_type('end_repeat') == 'end_repeat'
+    assert dealias_type('imei') == 'deviceid'
+    assert dealias_type('gps') == 'geopoint'
 
 
 def _fail_type(_type):
@@ -88,6 +90,28 @@ def test_settings_get_replaced():
     # no change
     _setting('form_title', 'form_title')
     _setting('sms_keyword', 'sms_keyword')
+
+
+def test_custom_allowed_types():
+    ex1 = replace_aliases({'survey': [{'type': 'x_y_z_a_b_c'}]}, allowed_types={
+            'xyzabc': 'x_y_z_a_b_c'
+        })
+    assert ex1['survey'][0]['type'] == 'xyzabc'
+
+    ex2 = replace_aliases({'survey': [{'type': 'xyzabc'}]}, allowed_types={
+            'xyzabc': ['x_y_z_a_b_c'],
+        })
+    assert ex2['survey'][0]['type'] == 'xyzabc'
+
+    ex3 = replace_aliases({'survey': [{'type': 'xyzabc'}]}, allowed_types={
+            'xyzabc': True,
+        })
+    assert ex3['survey'][0]['type'] == 'xyzabc'
+
+
+def test_list_name_renamed():
+    ex1 = replace_aliases({'choices': [{'list name': 'mylist'}]})
+    assert ex1['choices'][0].keys() == ['list_name']
 
 
 def _assert_column_converted_to(original, desired):

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,47 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+import json
+
+from formpack.validators import validate_row
+
+def test_row_validator():
+    '''
+    '''
+    rows = [
+        {'type': 'text', 'name': 'x', 'label': 'z'},
+        {'type': 'select_one', 'name': 'x', 'select_from_list_name': 'y', 'label': 'z'},
+        {'type': 'select_multiple', 'name': 'x', 'select_from_list_name': 'y', 'label': 'z'},
+        {'type': 'select_one_external', 'name': 'x', 'select_from_list_name': 'y', 'label': 'z'},
+        {u'appearance': u'label', u'type': u'select_one', u'name': u'ER_int_group2', u'select_from_list_name': u'emotion'},
+        {'type': 'note', 'name': 'x', 'media::image': 'y'},
+        # no names needed
+        {'type': 'end_group'},
+        {'type': 'end_repeat'},
+        {'type': 'begin_group', 'name': 'x', 'appearance': 'field-list'},
+    ]
+    for (i, row) in enumerate(rows):
+        validate_row(row, i)
+
+
+def test_row_validator_fails():
+    rows = [
+        # no list_name
+        {'type': 'select_one', 'name': 'x', 'label': 'z'},
+
+        # no name
+        {'type': 'text', 'label': 'x'},
+
+        # no label; no longer enforced because label can be either 'media::image', 'appearance', or 'label'
+        # {'type': 'text', 'name': 'x'},
+    ]
+    for (i, row) in enumerate(rows):
+        failed = False
+        try:
+            validate_row(row, i)
+        except Exception as e:
+            failed = True
+        if not failed:
+            raise AssertionError('row passed validator: {}'.format(json.dumps(row)))


### PR DESCRIPTION
* can verify against a json schema with FormPack parameter:
    `strict_schema=True`
* can pass custom parameters to "replace_aliases" to permit other types beyond the listed pyxform types
    `allowed_types={'custom_type': ['custom type aliases']}`