### PR TITLE
Add ellipsize_title parameter to formpack constructor

### DIFF
--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -29,7 +29,7 @@ class FormPack(object):
                  default_version_id_key='__version__',
                  strict_schema=False,
                  root_node_name='data',
-                 asset_type=None, submissions_xml=None):
+                 asset_type=None, submissions_xml=None, ellipsize_title=True):
 
         if not versions:
             versions = []
@@ -49,7 +49,8 @@ class FormPack(object):
         self.title = title
         self.strict_schema = strict_schema
 
-        if len(self.title) > 31: # excel sheet name size limit
+        # excel sheet name size limit
+        if ellipsize_title and len(self.title) > 31:
             self.title = self.title[:28] + '...'
 
         self.asset_type = asset_type

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -18,6 +18,14 @@ def test_fixture_has_translations():
     assert len(fp[1].translations) == 2
 
 
+def test_ellipsize_title():
+    title, schemas, submissions = build_fixture('grouped_repeatable')
+    fp = FormPack(schemas, title)
+    assert fp.title == 'Household survey with repeat...'
+    fp = FormPack(schemas, title, ellipsize_title=False)
+    assert fp.title == 'Household survey with repeatable groups'
+
+
 def test_to_dict():
     schema = build_fixture('restaurant_profile')[1][2]
     _copy = deepcopy(schema)


### PR DESCRIPTION
This allows to disable title ellipsizing, useful when displaying form preview in KoBoToolbox. (This comes with a corresponding kpi pull request to actually use that)