### PR TITLE
Keep all Excel sheet names under 31 characters.

### DIFF
--- a/src/formpack/constants.py
+++ b/src/formpack/constants.py
@@ -27,3 +27,8 @@ UNTRANSLATED = None
 OR_OTHER_COLUMN = '_or_other'
 # in the long run, the "select_one x or_other" syntax should be deprecated
 # because the or_other strings are not translatable
+
+# The Excel format supports worksheet names as long as 255 characters, but in
+# practice the Excel application has a 31-character limit.
+# http://stackoverflow.com/a/3681908
+EXCEL_SHEET_NAME_SIZE_LIMIT = 31

--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -29,7 +29,7 @@ class FormPack(object):
                  default_version_id_key='__version__',
                  strict_schema=False,
                  root_node_name='data',
-                 asset_type=None, submissions_xml=None, ellipsize_title=True):
+                 asset_type=None, submissions_xml=None):
 
         if not versions:
             versions = []
@@ -48,10 +48,6 @@ class FormPack(object):
 
         self.title = title
         self.strict_schema = strict_schema
-
-        # excel sheet name size limit
-        if ellipsize_title and len(self.title) > 31:
-            self.title = self.title[:28] + '...'
 
         self.asset_type = asset_type
 

--- a/src/formpack/reporting/export.py
+++ b/src/formpack/reporting/export.py
@@ -13,7 +13,7 @@ from pyexcelerate import Workbook
 
 from ..submission import FormSubmission
 from ..schema import CopyField
-from ..utils.string import unicode
+from ..utils.string import unicode, unique_name_for_xls
 from ..constants import UNSPECIFIED_TRANSLATION
 
 
@@ -420,15 +420,22 @@ class Export(object):
 
         sheets = {}
 
+        sheet_name_mapping = {}
+
         for chunk in self.parse_submissions(submissions):
             for section_name, rows in chunk.items():
-
                 try:
-                    cursor = sheets[section_name]
+                    sheet_name = sheet_name_mapping[section_name]
+                except KeyError:
+                    sheet_name = unique_name_for_xls(
+                        section_name, sheet_name_mapping.values())
+                    sheet_name_mapping[section_name] = sheet_name
+                try:
+                    cursor = sheets[sheet_name]
                     current_sheet = cursor['sheet']
                 except KeyError:
-                    current_sheet = workbook.new_sheet(section_name)
-                    cursor = sheets[section_name] = {
+                    current_sheet = workbook.new_sheet(sheet_name)
+                    cursor = sheets[sheet_name] = {
                         "sheet": current_sheet,
                         "row": 2,
                     }

--- a/src/formpack/utils/__init__.py
+++ b/src/formpack/utils/__init__.py
@@ -8,4 +8,4 @@ from .xform_tools import (parse_xmljson_to_data,
                           get_version_identifiers,
                           normalize_data_type,
                           )  # noqa
-from .string import slugify, randstr, str_types  # noqa
+from .string import slugify, randstr, str_types, unique_name_for_xls  # noqa

--- a/src/formpack/utils/string.py
+++ b/src/formpack/utils/string.py
@@ -8,6 +8,7 @@ import re
 import unicodedata
 import string
 import random
+from ..constants import EXCEL_SHEET_NAME_SIZE_LIMIT
 
 try:
     unicode = unicode
@@ -54,3 +55,47 @@ def slugify(string, separator=r'-'):
     string = re.sub(r'[^\w\s' + separator + ']', '', string, flags=re.U)
     string = string.strip().lower()
     return re.sub(r'[' + separator + '\s]+', separator, string, flags=re.U)
+
+
+def ellipsize(s, max_len, ellipsis='...'):
+    r"""
+    If necessary, truncate the string `s` and concatenate the result with
+    `ellipsis` such that the final string length does not exceed `max_len`.
+    :Example:
+        >>> ellipsize('This string has more than 31 characters!', max_len=31)
+        u'This string has more than 31...'
+    """
+
+    in_len = len(s)
+    ellipsis_len = len(ellipsis)
+    if max_len < ellipsis_len:
+        raise Exception(
+            '`max_len` cannot be less than the length of `ellipsis`')
+    if in_len > max_len:
+        slice_end = max_len - ellipsis_len
+        return s[:slice_end] + ellipsis
+    return s
+
+
+def unique_name_for_xls(sheet_name, other_sheet_names, base_ellipsis='...'):
+    r"""
+    Return a sheet name that does not collide with any string in the iterable
+    `other_sheet_names` and does not exceed the Excel sheet name length limit.
+    :Example:
+        >>> unique_name_for_xls(
+        ...     'This string has more than 31 characters!',
+        ...     ('This string has more than 31...',)
+        ... )
+        u'This string has more tha... (1)'
+    """
+
+    candidate = ellipsize(
+        sheet_name, EXCEL_SHEET_NAME_SIZE_LIMIT, base_ellipsis)
+    i = 1
+    while candidate in other_sheet_names:
+        candidate = ellipsize(
+            sheet_name, EXCEL_SHEET_NAME_SIZE_LIMIT, u'{} ({})'.format(
+                base_ellipsis, i)
+        )
+        i += 1
+    return candidate

--- a/tests/fixtures/long_names/__init__.py
+++ b/tests/fixtures/long_names/__init__.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+'''
+long_names
+
+'''
+
+from ..load_fixture_json import load_fixture_json
+
+DATA = {
+    u'title': u'long survey name: the quick, brown fox jumps over the lazy dog',
+    u'id_string': 'long_survey_name__the_quick__brown_fox_jumps_over_the_lazy_dog',
+    u'versions': [
+        load_fixture_json('long_names/v1'),
+    ],
+}

--- a/tests/fixtures/long_names/v1.json
+++ b/tests/fixtures/long_names/v1.json
@@ -3,7 +3,7 @@
   "content": {
     "survey": [
       {
-        "type": "begin repeat",
+        "type": "begin_repeat",
         "name": "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich",
         "label": "long group name: Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich"
       },
@@ -15,10 +15,10 @@
         "select_from_list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz"
       },
       {
-        "type": "end repeat"
+        "type": "end_repeat"
       },
       {
-        "type": "begin repeat",
+        "type": "begin_repeat",
         "name": "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2",
         "label": "long group name: Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich 2"
       },
@@ -30,7 +30,7 @@
         "select_from_list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz_2"
       },
       {
-        "type": "end repeat"
+        "type": "end_repeat"
       },
       {
         "type": "start",

--- a/tests/fixtures/long_names/v1.json
+++ b/tests/fixtures/long_names/v1.json
@@ -1,0 +1,95 @@
+{
+  "version": "long_survey_name__the_quick__brown_fox_jumps_over_the_lazy_dog_v1",
+  "content": {
+    "survey": [
+      {
+        "type": "begin repeat",
+        "name": "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich",
+        "label": "long group name: Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich"
+      },
+      {
+        "required": "true",
+        "type": "select_one",
+        "name": "long_question_name__how_vexingly_quick__daft_zebras_jump",
+        "label": "long question name: how vexingly quick, daft zebras jump",
+        "select_from_list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz"
+      },
+      {
+        "type": "end repeat"
+      },
+      {
+        "type": "begin repeat",
+        "name": "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2",
+        "label": "long group name: Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich 2"
+      },
+      {
+        "required": "true",
+        "type": "select_one",
+        "name": "long_question_name__how_vexingly_quick__daft_zebras_jump_2",
+        "label": "long question name: how vexingly quick, daft zebras jump 2",
+        "select_from_list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz_2"
+      },
+      {
+        "type": "end repeat"
+      },
+      {
+        "type": "start",
+        "name": "start"
+      },
+      {
+        "type": "end",
+        "name": "end"
+      }
+    ],
+    "choices": [
+      {
+        "label": "long option name: Pack my box with five dozen liquor jugs",
+        "name": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs",
+        "list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz"
+      },
+      {
+        "label": "long option name: Pack my box with five dozen liquor jugs 2",
+        "name": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs_2",
+        "list_name": "long_choice_list_name__jackdaws_love_my_big_sphinx_of_quartz_2"
+      }
+    ]
+  },
+  "submissions": [
+    {
+      "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich": [
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich/long_question_name__how_vexingly_quick__daft_zebras_jump": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs"
+        },
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich/long_question_name__how_vexingly_quick__daft_zebras_jump": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs"
+        }
+      ],
+      "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2": [
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2/long_question_name__how_vexingly_quick__daft_zebras_jump_2": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs_2"
+        },
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2/long_question_name__how_vexingly_quick__daft_zebras_jump_2": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs_2"
+        }
+      ],
+      "start": "2017-03-13T11:25:31.707-04",
+      "end": "2017-03-13T11:26:10.638-04",
+      "meta/instanceID": "uuid:296c2960-c910-474b-b4cc-e2917cd29926"
+    },
+    {
+      "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich": [
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich/long_question_name__how_vexingly_quick__daft_zebras_jump": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs"
+        }
+      ],
+      "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2": [
+        {
+          "long_group_name__Victor_jagt_zw_lf_Boxk_mpfer_quer__ber_den_gro_en_Sylter_Deich_2/long_question_name__how_vexingly_quick__daft_zebras_jump_2": "long_option_name__Pack_my_box_with_five_dozen_liquor_jugs_2"
+        }
+      ],
+      "start": "2017-03-13T11:26:15.317-04",
+      "end": "2017-03-13T11:26:27.332-04",
+      "meta/instanceID": "uuid:63c6bb42-6bd8-41e3-a2c3-41ef952c288e"
+    }
+  ]
+}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -5,6 +5,7 @@ from __future__ import (unicode_literals, print_function,
 
 import unittest
 import json
+import xlrd
 
 from textwrap import dedent
 
@@ -231,7 +232,7 @@ class TestFormPackExport(unittest.TestCase):
         options = {'versions': 'rgv1'}
         export = fp.export(**options).to_dict(submissions)
         self.assertEqual(export, OrderedDict([
-                            ('Household survey with repeat...',
+                            ('Household survey with repeatable groups',
                                 {
                                     'fields': [
                                         'start',
@@ -288,67 +289,67 @@ class TestFormPackExport(unittest.TestCase):
                                     'data': [
                                         [
                                             'peter',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             1
                                         ],
                                         [
                                             'kyle',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             2
                                         ],
                                         [
                                             'linda',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             2
                                         ],
                                         [
                                             'morty',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             3
                                         ],
                                         [
                                             'tony',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             4
                                         ],
                                         [
                                             'mary',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             4
                                         ],
                                         [
                                             'emma',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             5
                                         ],
                                         [
                                             'parker',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             5
                                         ],
                                         [
                                             'amadou',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             6
                                         ],
                                         [
                                             'esteban',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             6
                                         ],
                                         [
                                             'suzie',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             6
                                         ],
                                         [
                                             'fiona',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             6
                                         ],
                                         [
                                             'phillip',
-                                            'Household survey with repeat...',
+                                            'Household survey with repeatable groups',
                                             6
                                         ]
                                     ]
@@ -689,6 +690,30 @@ class TestFormPackExport(unittest.TestCase):
             xls = d / 'foo.xlsx'
             fp.export(**options).to_xlsx(xls, submissions)
             assert xls.isfile()
+
+    def test_xlsx_sheet_name_limit(self):
+        '''
+        PyExcelerate will raise the following if any sheet name exceeds 31
+        characters:
+            Exception: Excel does not permit worksheet names longer than 31
+            characters. Set force_name=True to disable this restriction.
+        '''
+        title, schemas, submissions = build_fixture('long_names')
+        fp = FormPack(schemas, title)
+        options = {'versions': 'long_survey_name__the_quick__brown_fox_jumps'
+                               '_over_the_lazy_dog_v1'}
+
+        with tempdir() as d:
+            xls = d / 'foo.xlsx'
+            fp.export(**options).to_xlsx(xls, submissions)
+            assert xls.isfile()
+            book = xlrd.open_workbook(xls)
+            assert book.sheet_names() == [
+                u'long survey name: the quick,...',
+                u'long_group_name__Victor_jagt...',
+                u'long_group_name__Victor_... (1)'
+            ]
+
 
     def test_force_index(self):
         title, schemas, submissions = customer_satisfaction

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -18,14 +18,6 @@ def test_fixture_has_translations():
     assert len(fp[1].translations) == 2
 
 
-def test_ellipsize_title():
-    title, schemas, submissions = build_fixture('grouped_repeatable')
-    fp = FormPack(schemas, title)
-    assert fp.title == 'Household survey with repeat...'
-    fp = FormPack(schemas, title, ellipsize_title=False)
-    assert fp.title == 'Household survey with repeatable groups'
-
-
 def test_to_dict():
     schema = build_fixture('restaurant_profile')[1][2]
     _copy = deepcopy(schema)


### PR DESCRIPTION
Fixes #122. Moves code pertaining to this limitation out of the formpack core
and places it exclusively within the Excel export logic.

Once this is merged, we will need to update [the pinned formpack commit in KPI's requirements](https://github.com/kobotoolbox/kpi/blob/dbf0a09be819f915a788c31924f89c392b890f52/requirements/requirements.txt#L8) and remove [the reference to `ellipsize_title`](https://github.com/kobotoolbox/kpi/blob/dbf0a09be819f915a788c31924f89c392b890f52/kpi/models/asset.py#L762) from the `AssetSnapshot` code.