### PR TITLE
Support exporting tag column values

### DIFF
--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -271,7 +271,8 @@ class FormPack(object):
 
     def export(self, lang=UNSPECIFIED_TRANSLATION, group_sep='/', hierarchy_in_labels=False,
                versions=-1, multiple_select="both",
-               force_index=False, copy_fields=(), title=None):
+               force_index=False, copy_fields=(), title=None,
+               tag_cols_for_header=[]):
         '''Create an export for a given versions of the form'''
 
         versions = self._get_versions(versions)
@@ -280,7 +281,8 @@ class FormPack(object):
                       hierarchy_in_labels=hierarchy_in_labels,
                       version_id_keys=self.version_id_keys(versions),
                       title=title, multiple_select=multiple_select,
-                      force_index=force_index, copy_fields=copy_fields)
+                      force_index=force_index, copy_fields=copy_fields,
+                      tag_cols_for_header=tag_cols_for_header)
 
     def autoreport(self, versions=-1):
         '''Create an automatic report for a given versions of the form'''

--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -37,6 +37,7 @@ class FormField(FormDataDef):
         self.data_type = data_type
         self.section = section
         self.can_format = can_format
+        self.tags = kwargs.get('tags', [])
 
         hierarchy = list(hierarchy) if hierarchy is not None else [None]
         self.hierarchy = hierarchy + [self]
@@ -129,6 +130,7 @@ class FormField(FormDataDef):
                   The FormField instance matching this definiton.
         """
         name = definition['name']
+        tags = definition.get('tags', [])
         label = definition.get('label')
         if label:
             labels = OrderedDict(zip(translations, label))
@@ -169,6 +171,7 @@ class FormField(FormDataDef):
         args = {
             'name': name,
             'labels': labels,
+            'tags': tags,
             'data_type': data_type,
             'hierarchy': hierarchy,
             'section': section,

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -41,6 +41,28 @@ def _expand_translatable_content(content, row, col_shortname,
             del row[col_shortname]
 
 
+def _expand_tags(row, tag_cols=None):
+    if tag_cols is None:
+        tag_cols = []
+    tags = []
+    main_tags = row.pop('tags', None)
+    if main_tags:
+        if isinstance(main_tags, basestring):
+            tags = tags + main_tags.split()
+        elif isinstance(main_tags, list):
+            # carry over any tags listed here
+            tags = main_tags
+
+    for tag_col in tag_cols:
+        tags_str = row.get(tag_col)
+        if tags_str and isinstance(tags_str, basestring):
+            for tag in re.findall('([\#\+][a-zA-Z][a-zA-Z0-9]*)', tags_str):
+                tags.append('hxl:%s' % tag)
+    if len(tags) > 0:
+        row['tags'] = tags
+    return row
+
+
 def _get_translations_from_special_cols(special_cols, translations):
     translated_cols = []
     for (colname, parsedvals) in special_cols.iteritems():
@@ -77,6 +99,9 @@ def expand_content_in_place(content):
                 _list_name = _type.values()[0]
                 row.update({u'type': _type_str,
                             u'select_from_list_name': _list_name})
+
+        _expand_tags(row, tag_cols=['hxl'])
+
         for key in EXPANDABLE_FIELD_TYPES:
             if key in row and isinstance(row[key], basestring):
                 row[key] = _expand_xpath_to_list(row[key])

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -54,7 +54,7 @@ def _expand_tags(row, tag_cols=None):
             tags = main_tags
 
     for tag_col in tag_cols:
-        tags_str = row.get(tag_col)
+        tags_str = row.pop(tag_col, None)
         if tags_str and isinstance(tags_str, basestring):
             for tag in re.findall('([\#\+][a-zA-Z][a-zA-Z0-9]*)', tags_str):
                 tags.append('hxl:%s' % tag)

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -77,6 +77,14 @@ def _stringify_type__depr(json_qtype):
         return 'select_one %s or_other' % json_qtype['select_one_or_other']
 
 
+def flatten_tag_list(tag_list, tag_cols=[]):
+    '''
+    takes a list of tags and reassigns them to the tag column in which they
+    appear on import of xls
+    '''
+    return _flatten_tags({'tags': tag_list}, tag_cols)
+
+
 def _flatten_tags(row, tag_cols=[]):
     '''
     takes a "tags" column with an array of tags and

--- a/src/formpack/utils/spreadsheet_content.py
+++ b/src/formpack/utils/spreadsheet_content.py
@@ -3,6 +3,7 @@ from copy import deepcopy, copy
 from collections import OrderedDict, defaultdict
 
 from .flatten_content import (_flatten_translated_fields, _flatten_survey_row,
+                              _flatten_tags,
                               translated_col_list)
 
 # xlsform specific ordering preferences
@@ -52,7 +53,6 @@ def flatten_to_spreadsheet_content(content,
         content['settings'] = [content['settings']]
     sheet_names = _order_sheet_names(filter(lambda x: x not in remove_sheets,
                                             content.keys()))
-
     def _row_to_ordered_dict(row, dest):
         _flatten_translated_fields(row, translations, translated_cols,
                                    col_order=dest.keys(),
@@ -79,7 +79,6 @@ def flatten_to_spreadsheet_content(content,
         mids = list(filter(lambda x: x not in _not_mids, _all_cols))
 
         ordered_cols = translated_col_list((firsts + mids + lasts), translations, translated_cols)
-
         return [
             _row_to_ordered_dict(row, OrderedDict.fromkeys(ordered_cols)) for row in rows
         ]
@@ -92,6 +91,9 @@ def flatten_to_spreadsheet_content(content,
     all_sheets = content.keys()
     for sheet_name in sheet_names:
         rows = content.pop(sheet_name)
+        for row in rows:
+            if 'tags' in row:
+                _flatten_tags(row, tag_cols=['hxl'])
         if sheet_name in all_sheets:
             all_sheets.remove(sheet_name)
         _od[sheet_name] = _sheet_to_ordered_dicts(sheet_name, rows)

--- a/tests/fixtures/dietary_needs/v1.json
+++ b/tests/fixtures/dietary_needs/v1.json
@@ -1,39 +1,57 @@
 {
-    "name": "Dietary needs",
-    "id_string": "dietary_needs",
+    "version": "dietv1",
     "content": {
         "survey": [
             {
+                "name": "restaurant_name",
                 "required": "true",
                 "type": "text",
-                "label": "Restaurant name"
+                "label": "Restaurant name",
+                "hxl": "#loc+name"
             },
             {
+                "name": "dietary_accommodations",
                 "required": "true",
-                "type": {
-                    "select_multiple": {
-                        "choices": [
-                            {
-                                "name": "gluten_free",
-                                "label": "Gluten-free"
-                            },
-                            {
-                                "name": "vegan",
-                                "label": "Vegan"
-                            },
-                            {
-                                "name": "vegetarian",
-                                "label": "Vegetarian"
-                            },
-                            {
-                                "name": "lactose_free",
-                                "label": "Lactose-free"
-                            }
-                        ]
-                    }
-                },
-                "label": "Accommodating of dietary needs"
+                "type": "select_multiple dietary_needs",
+                "label": "Accommodating of dietary needs",
+                "hxl": "#indicator+diet"
+            }
+        ],
+        "choices": [
+            {
+                "list_name": "dietary_needs",
+                "name": "gluten_free",
+                "label": "Gluten-free"
+            },
+            {
+                "list_name": "dietary_needs",
+                "name": "vegan",
+                "label": "Vegan"
+            },
+            {
+                "list_name": "dietary_needs",
+                "name": "vegetarian",
+                "label": "Vegetarian"
+            },
+            {
+                "list_name": "dietary_needs",
+                "name": "lactose_free",
+                "label": "Lactose-free"
             }
         ]
-    }
+    },
+    "submissions": [
+        {
+            "restaurant_name": "Melba's",
+            "dietary_accommodations": "gluten_free"
+        },
+        {
+            "restaurant_name": "Land of Kush",
+            "dietary_accommodations": "vegan vegetarian"
+        },
+        {
+            "restaurant_name": "Sweet 27",
+            "dietary_accommodations": "gluten_free vegan vegetarian lactose_free"
+        }
+    ]
 }

--- a/tests/fixtures/hxl_grouped_repeatable/__init__.py
+++ b/tests/fixtures/hxl_grouped_repeatable/__init__.py
@@ -4,18 +4,16 @@ from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
 '''
-dietary_needs:
-
- * has a select_multiple (described in a different syntax)
+hxl_grouped_repeatable
 
 '''
 
 from ..load_fixture_json import load_fixture_json
 
 DATA = {
-    u'title': u'Dietary needs',
-    u'id_string': 'dietary_needs',
+    u'title': u'Household survey with HXL and repeatable groups',
+    u'id_string': 'hxl_grouped_repeatable',
     u'versions': [
-        load_fixture_json('dietary_needs/v1'),
+        load_fixture_json('hxl_grouped_repeatable/v1'),
     ],
 }

--- a/tests/fixtures/hxl_grouped_repeatable/v1.json
+++ b/tests/fixtures/hxl_grouped_repeatable/v1.json
@@ -1,0 +1,148 @@
+{
+    "version": "hxl_rgv1",
+    "content": {
+        "survey": [
+            {
+                "type": "begin group",
+                "name": "household_visit",
+                "label": "Household visit"
+            },
+            {
+                "required": "true",
+                "type": "text",
+                "name": "household_location",
+                "label": "household location",
+                "hxl": "#loc+name"
+            },
+            {
+                "type": "begin repeat",
+                "name": "houshold_member_repeat",
+                "label": "For each household member"
+            },
+            {
+                "required": "true",
+                "type": "text",
+                "name": "household_member_name",
+                "label": "household member name",
+                "hxl": "#beneficiary"
+            },
+            {
+                "type": "end repeat"
+            },
+            {
+                "type": "end group"
+            },
+            {
+                "type": "start",
+                "name": "start",
+                "hxl": "#date+start"
+            },
+            {
+                "type": "end",
+                "name": "end",
+                "hxl": "#date+end"
+            }
+        ]
+    },
+    "submissions": [
+        {
+            "household_visit/household_location": "montreal",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "peter"
+                }
+            ],
+            "start": "2016-03-14T14:15:48.000-04:00",
+            "end": "2016-03-14T14:18:35.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:91ab8237-92b1-4a10-929f-45af2bb141c0",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ac"
+        },
+        {
+            "household_visit/household_location": "marseille",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "kyle"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "linda"
+                }
+            ],
+            "start": "2016-03-14T14:14:10.000-04:00",
+            "end": "2016-03-14T14:15:48.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:91ab8237-92b1-4a10-929f-45af2bb141b9",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ab"
+        },
+        {
+            "household_visit/household_location": "rocky mountains",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "morty"
+                }
+            ],
+            "start": "2016-03-14T14:13:53.000-04:00",
+            "end": "2016-03-14T14:14:10.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:bd2a1d30-bcff-4c12-8fdd-5cc9b5c2ce7a",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ab"
+        },
+        {
+            "household_visit/household_location": "toronto",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "tony"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "mary"
+                }
+            ],
+            "start": "2016-03-14T14:12:54.000-04:00",
+            "end": "2016-03-14T14:13:53.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:cfc8d79f-e519-4bb9-9eec-0ba04146e698",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ab"
+        },
+        {
+            "household_visit/household_location": "new york",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "emma"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "parker"
+                }
+            ],
+            "start": "2016-03-14T14:18:35.000-04:00",
+            "end": "2016-03-14T15:19:20.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:4ee0afe4-d64c-43d4-8349-ec30173f4a2e",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ab"
+        },
+        {
+            "household_visit/household_location": "boston",
+            "household_visit/houshold_member_repeat": [
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "amadou"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "esteban"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "suzie"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "fiona"
+                },
+                {
+                    "household_visit/houshold_member_repeat/household_member_name": "phillip"
+                }
+            ],
+            "start": "2016-03-14T14:11:25.000-04:00",
+            "end": "2016-03-14T14:12:03.000-04:00",
+            "meta/versionID": "hxl_rgv1",
+            "meta/instanceID": "uuid:ce94b951-9a38-4701-8c36-17a4b3ea15c9",
+            "meta/formUID": "9677d34e6ad14302afed5aa2951c28ab"
+        }
+    ]
+}

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -362,6 +362,7 @@ def test_expand_hxl_tags():
     s1 = {'survey': [{'type': 'text',
                       'hxl': '#tag+attr'}]}
     expand_content(s1, in_place=True)
+    assert 'hxl' not in s1['survey'][0]
     assert s1['survey'][0]['tags'] == ['hxl:#tag', 'hxl:+attr']
 
 

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -7,6 +7,7 @@ import copy
 from collections import OrderedDict
 
 from formpack.utils.expand_content import expand_content, _expand_type_to_dict
+from formpack.utils.expand_content import _expand_tags
 from formpack.utils.expand_content import _get_special_survey_cols
 from formpack.utils.expand_content import SCHEMA_VERSION
 from formpack.utils.flatten_content import flatten_content
@@ -355,6 +356,25 @@ def test_expand_translations():
                               'label::English': 'OK?',
                               'label::Français': 'OK!'}],
                   }
+
+
+def test_expand_hxl_tags():
+    s1 = {'survey': [{'type': 'text',
+                      'hxl': '#tag+attr'}]}
+    expand_content(s1, in_place=True)
+    assert s1['survey'][0]['tags'] == ['hxl:#tag', 'hxl:+attr']
+
+
+def test_expand_tags_method():
+    def _expand(tag_str, existing_tags=None):
+        row = {'hxl': tag_str}
+        if existing_tags:
+            row['tags'] = existing_tags
+        return sorted(_expand_tags(row, tag_cols=['hxl'])['tags'])
+    expected = sorted(['hxl:#tag1', 'hxl:+attr1', 'hxl:+attr2'])
+    assert expected == _expand('#tag1+attr1+attr2')
+    assert expected == _expand(' #tag1 +attr1 +attr2 ')
+    assert expected == _expand(' #tag1 +attr1 ', ['hxl:+attr2'])
 
 
 def test_expand_translations_null_lang():

--- a/tests/test_utils_flatten_content.py
+++ b/tests/test_utils_flatten_content.py
@@ -12,6 +12,7 @@ from formpack.utils.flatten_content import flatten_content, translated_col_list
 from formpack.utils.json_hash import json_hash
 from formpack.utils.spreadsheet_content import (flatten_to_spreadsheet_content,
                                                 _order_cols,
+                                                _flatten_tags,
                                                 _order_sheet_names)
 
 
@@ -337,6 +338,40 @@ def test_flatten_to_spreadsheet_content():
     _c = flatten_to_spreadsheet_content(_e)
     assert isinstance(_c, OrderedDict)
     assert _c.keys() == ['survey', 'choices', 'settings']
+
+
+def test_flatten_tags_util_method():
+    assert _flatten_tags({'tags': ['a']})['tags'] == 'a'
+    assert _flatten_tags({'tags': ['a', 'b']})['tags'] == 'a b'
+
+    assert _flatten_tags(
+        {'tags': ['a', 'zz:b']}, tag_cols=['zz']
+        ) == {'tags': 'a', 'zz': 'b'}
+
+    assert _flatten_tags(
+        {'tags': ['a', 'hxl:b']}, tag_cols=['hxl']
+        ) == {'tags': 'a', 'hxl': 'b'}
+
+    assert _flatten_tags(
+        {'tags': ['a', 'hxl:b', 'hxl:c']}, tag_cols=['hxl']
+        ) == {'tags': 'a', 'hxl': 'b c'}
+
+    assert _flatten_tags(
+        {'tags': ['a', 'hxl:b', 'hxl:c', 'd']}, tag_cols=['hxl']
+        ) == {'tags': 'a d', 'hxl': 'b c'}
+
+
+def test_flatten_tags():
+    _e = {
+        'survey': [
+            {'type': 'text', 'name': 'q1',
+                'label': 'lang1',
+                'tags': ['hxl:x', 'hxl:y', 'hxl:z'],
+             },
+        ],
+    }
+    _c = flatten_to_spreadsheet_content(_e)
+    assert _c['survey'][0]['hxl'] == 'x y z'
 
 
 def test_col_order():

--- a/tests/test_utils_flatten_content.py
+++ b/tests/test_utils_flatten_content.py
@@ -8,7 +8,9 @@ import pytest
 from collections import OrderedDict
 from formpack.constants import OR_OTHER_COLUMN
 from formpack.utils.xls_to_ss_structure import _parsed_sheet
-from formpack.utils.flatten_content import flatten_content, translated_col_list
+from formpack.utils.flatten_content import (flatten_content,
+                                            flatten_tag_list,
+                                            translated_col_list)
 from formpack.utils.json_hash import json_hash
 from formpack.utils.spreadsheet_content import (flatten_to_spreadsheet_content,
                                                 _order_cols,
@@ -358,6 +360,27 @@ def test_flatten_tags_util_method():
 
     assert _flatten_tags(
         {'tags': ['a', 'hxl:b', 'hxl:c', 'd']}, tag_cols=['hxl']
+        ) == {'tags': 'a d', 'hxl': 'b c'}
+
+
+def test_flatten_tag_list_util_method():
+    assert flatten_tag_list(['a'])['tags'] == 'a'
+    assert flatten_tag_list(['a', 'b'])['tags'] == 'a b'
+
+    assert flatten_tag_list(
+        ['a', 'zz:b'], tag_cols=['zz']
+        ) == {'tags': 'a', 'zz': 'b'}
+
+    assert flatten_tag_list(
+        ['a', 'hxl:b'], tag_cols=['hxl']
+        ) == {'tags': 'a', 'hxl': 'b'}
+
+    assert flatten_tag_list(
+        ['a', 'hxl:b', 'hxl:c'], tag_cols=['hxl']
+        ) == {'tags': 'a', 'hxl': 'b c'}
+
+    assert flatten_tag_list(
+        ['a', 'hxl:b', 'hxl:c', 'd'], tag_cols=['hxl']
         ) == {'tags': 'a d', 'hxl': 'b c'}
 
 


### PR DESCRIPTION
as secondary header rows. Includes @dorey's work to support expanding and flattening `hxl` columns in XLSForms. Closes #134