### PR TITLE
Add new literacy test field type

### DIFF
--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -98,8 +98,9 @@ class FormPack(object):
         _stats['id_string'] = self.id_string
         _stats['versions'] = len(self.versions)
         # _stats['submissions'] = self.submissions_count()
-        _stats['row_count'] = len(self[-1].schema.get('content', {})
-                                                 .get('survey', []))
+        if self.versions:
+            _stats['row_count'] = len(self[-1].schema.get('content', {})
+                                                     .get('survey', []))
         # returns stats in the format [ key="value" ]
         return '\n\t'.join('%s="%s"' % item for item in _stats.items())
 

--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -132,6 +132,7 @@ class FormField(FormDataDef):
         name = definition['name']
         tags = definition.get('tags', [])
         labels = cls._extract_json_labels(definition, translations)
+        appearance = definition.get('appearance')
 
         # normalize spaces
         data_type = definition['type']
@@ -173,6 +174,10 @@ class FormField(FormDataDef):
             'section': section,
             'choice': choice
         }
+
+        if data_type == 'select_multiple' and appearance == 'literacy':
+            return FormLiteracyTestField(**args)
+
         return data_type_classes.get(data_type, cls)(**args)
 
     def format(self, val, lang=UNSPECIFIED_TRANSLATION, context=None):
@@ -747,3 +752,59 @@ class FormChoiceFieldWithMultipleSelect(FormChoiceField):
     def parse_values(self, raw_values):
         for x in raw_values.split():
             yield x
+
+
+class FormLiteracyTestField(FormChoiceFieldWithMultipleSelect):
+    '''
+    Like a FormChoiceFieldWithMultipleSelect, but with extra parameters
+    prepended that do not correspond to choice values. In the submission, the
+    parameters are submitted as a space-separated list of integers, nulls and
+    word values, e.g.
+        5 45 99 null null null null null null null 1 4 5 6
+    The fields are:
+        1    Word attempted at flash point
+        2    Time taken for whole exercise
+        3    Total words attempted
+        4-10 Reserved for possible future parameters (set to null until then)
+        11-  Values of words read incorrectly (as in a typical multiple select)
+    '''
+
+    PREPENDED_PARAMETERS = [
+        # FIXME: what's the exact wording that STC wants here?
+        'Word at flash',
+        'Duration of exercise',
+        'Total words attempted',
+        # Reserved parameters must be listed at the end and labeled `None`
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    ]
+
+    def __init__(self, *args, **kwargs):
+        self.parameters_in_use = [
+            label for label in self.PREPENDED_PARAMETERS if label is not None]
+        return super(FormChoiceFieldWithMultipleSelect, self).__init__(
+            *args, **kwargs)
+
+    def get_labels(self, *args, **kwargs):
+        word_labels = super(FormLiteracyTestField, self).get_labels(
+            *args, **kwargs)
+        return self.parameters_in_use + word_labels
+
+    def get_value_names(self, *args, **kwargs):
+        word_value_names = super(FormLiteracyTestField, self).get_value_names(
+            *args, **kwargs)
+        return self.parameters_in_use + word_value_names
+
+    def format(self, val, *args, **kwargs):
+        all_values = val.split()
+        prepended_cells = dict(zip(self.parameters_in_use, all_values))
+        word_values = all_values[len(self.PREPENDED_PARAMETERS):]
+        cells = super(FormLiteracyTestField, self).format(
+            ' '.join(word_values), *args, **kwargs)
+        cells.update(prepended_cells)
+        return cells

--- a/tests/fixtures/literacy_test/__init__.py
+++ b/tests/fixtures/literacy_test/__init__.py
@@ -1,0 +1,19 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+'''
+literacy_test
+
+'''
+
+from ..load_fixture_json import load_fixture_json
+
+DATA = {
+    u'title': u'Literacy test',
+    u'id_string': 'literacy_test',
+    u'versions': [
+        load_fixture_json('literacy_test/v1'),
+    ],
+}

--- a/tests/fixtures/literacy_test/v1.json
+++ b/tests/fixtures/literacy_test/v1.json
@@ -1,0 +1,386 @@
+{
+  "version": "literacy_test_v1",
+  "content": {
+    "choices": [
+      {
+        "list_name": "russian_words",
+        "name": "1",
+        "label": [
+          "Гуляла"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "2",
+        "label": [
+          "курочка"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "3",
+        "label": [
+          "с"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "4",
+        "label": [
+          "цыплятами"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "5",
+        "label": [
+          "по"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "6",
+        "label": [
+          "двору."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "7",
+        "label": [
+          "Вдруг"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "8",
+        "label": [
+          "пошёл"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "9",
+        "label": [
+          "дождик."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "10",
+        "label": [
+          "Курочка"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "11",
+        "label": [
+          "быстро"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "12",
+        "label": [
+          "на"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "13",
+        "label": [
+          "землю"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "14",
+        "label": [
+          "присела,"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "15",
+        "label": [
+          "перья"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "16",
+        "label": [
+          "растопырила,"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "17",
+        "label": [
+          "громко"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "18",
+        "label": [
+          "закудахтала."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "19",
+        "label": [
+          "Это"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "20",
+        "label": [
+          "означало:"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "21",
+        "label": [
+          "прячьтесь"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "22",
+        "label": [
+          "скорей."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "23",
+        "label": [
+          "Детки"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "24",
+        "label": [
+          "поспешили"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "25",
+        "label": [
+          "к"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "26",
+        "label": [
+          "маме"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "27",
+        "label": [
+          "под"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "28",
+        "label": [
+          "крылья."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "29",
+        "label": [
+          "Двое"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "30",
+        "label": [
+          "цыплят"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "31",
+        "label": [
+          "не"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "32",
+        "label": [
+          "послушались"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "33",
+        "label": [
+          "её,"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "34",
+        "label": [
+          "не"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "35",
+        "label": [
+          "спрятались."
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "36",
+        "label": [
+          "Бегают,"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "37",
+        "label": [
+          "пищат"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "38",
+        "label": [
+          "и"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "39",
+        "label": [
+          "удивляются:"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "40",
+        "label": [
+          "что"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "41",
+        "label": [
+          "это"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "42",
+        "label": [
+          "такое"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "43",
+        "label": [
+          "им"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "44",
+        "label": [
+          "на"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "45",
+        "label": [
+          "голову"
+        ]
+      },
+      {
+        "list_name": "russian_words",
+        "name": "46",
+        "label": [
+          "капает?"
+        ]
+      }
+    ],
+    "survey": [
+      {
+        "select_from_list_name": "russian_words",
+        "name": "russian_passage_1",
+        "appearance": "literacy",
+        "label": [
+          "Reading test 1 (flash at 10)"
+        ],
+        "body::kb:flash": "10",
+        "type": "select_multiple"
+      },
+      {
+        "select_from_list_name": "russian_words",
+        "name": "russian_passage_2",
+        "appearance": "literacy",
+        "label": [
+          "Reading test 2 (flash at 5)"
+        ],
+        "body::kb:flash": "5",
+        "type": "select_multiple"
+      }
+    ]
+  },
+  "submissions": [
+    {
+      "meta/instanceID": "uuid:7e1d7b7f-8aa1-41aa-b5a8-c8f0ab1a1473",
+      "russian_passage_1": "22 16 46 null null null null null null null 1 2 4 8 10 19 20 21 29 30 33 39 46",
+      "_submission_time": "2018-01-09T03:21:40",
+      "_uuid": "7e1d7b7f-8aa1-41aa-b5a8-c8f0ab1a1473",
+      "russian_passage_2": "21 9 46 null null null null null null null 1 5 14 16 30 32 39",
+      "_status": "submitted_via_web",
+      "_id": 3281043,
+      "__version__": "literacy_test_v1",
+      "formhub/uuid": "1a7f6fc38dd64c128b173539e728d00c"
+    },
+    {
+      "meta/instanceID": "uuid:1eb23383-3c3e-43c6-bd45-359f30f82db4",
+      "russian_passage_1": "46 14 46 null null null null null null null 1 2 3 4 5 6 7 8 9",
+      "_submission_time": "2018-01-09T05:40:54",
+      "_uuid": "1eb23383-3c3e-43c6-bd45-359f30f82db4",
+      "russian_passage_2": "45 7 46 null null null null null null null 1 11 29 46",
+      "_status": "submitted_via_web",
+      "_id": 3281044,
+      "__version__": "literacy_test_v1",
+      "formhub/uuid": "1a7f6fc38dd64c128b173539e728d00c"
+    },
+    {
+      "meta/instanceID": "uuid:563408aa-b3c8-4c46-ba46-62e58f9d8a56",
+      "russian_passage_1": "9 12 46 null null null null null null null 1 2 3 4 6 7 8",
+      "_submission_time": "2018-01-09T05:41:33",
+      "_uuid": "563408aa-b3c8-4c46-ba46-62e58f9d8a56",
+      "russian_passage_2": "33 7 36 null null null null null null null 1 11 20 30 32",
+      "_status": "submitted_via_web",
+      "_id": 3281045,
+      "__version__": "literacy_test_v1",
+      "formhub/uuid": "1a7f6fc38dd64c128b173539e728d00c"
+    }
+  ]
+}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1363,3 +1363,73 @@ class TestFormPackExport(unittest.TestCase):
             'is_plant_life_encroaching',
             'please_rate_the_impact_of_any_defects_observed',
         ])
+
+    def test_literacy_test_export(self):
+        title, schemas, submissions = build_fixture('literacy_test')
+        fp = FormPack(schemas, title)
+        export = fp.export(versions=fp.versions.keys()).to_dict(submissions)
+        headers = export['Literacy test']['fields']
+        expected_headers = (
+            [
+                 'russian_passage_1/Word at flash',
+                 'russian_passage_1/Duration of exercise',
+                 'russian_passage_1/Total words attempted',
+                 'russian_passage_1',
+            ] + ['russian_passage_1/' + str(i) for i in range(1, 47)] + [
+                 'russian_passage_2/Word at flash',
+                 'russian_passage_2/Duration of exercise',
+                 'russian_passage_2/Total words attempted',
+                 'russian_passage_2',
+            ] + ['russian_passage_2/' + str(i) for i in range(1, 47)]
+        )
+        self.assertListEqual(headers, expected_headers)
+        expected_data = [
+            [
+                # Word at flash, duration of exercise, total words attempted
+                '22', '16', '46',
+                # Incorrect words as list in single column
+                '1 2 4 8 10 19 20 21 29 30 33 39 46',
+                # Incorrect words as binary values in separate columns
+                '1', '1', '0', '1', '0', '0', '0', '1', '0', '1', '0', '0',
+                '0', '0', '0', '0', '0', '0', '1', '1', '1', '0', '0', '0',
+                '0', '0', '0', '0', '1', '1', '0', '0', '1', '0', '0', '0',
+                '0', '0', '1', '0', '0', '0', '0', '0', '0', '1',
+                # All the same for the  second literacy test question
+                '21', '9', '46',
+                '1 5 14 16 30 32 39',
+                '1', '0', '0', '0', '1', '0', '0', '0', '0', '0', '0', '0',
+                '0', '1', '0', '1', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '1', '0', '1', '0', '0', '0', '0',
+                '0', '0', '1', '0', '0', '0', '0', '0', '0', '0',
+            ], [
+                '46', '14', '46',
+                '1 2 3 4 5 6 7 8 9',
+                '1', '1', '1', '1', '1', '1', '1', '1', '1', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '45', '7', '46',
+                '1 11 29 46',
+                '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '1', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '1',
+            ], [
+                '9', '12', '46',
+                '1 2 3 4 6 7 8',
+                '1', '1', '1', '1', '0', '1', '1', '1', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+                '33', '7', '36',
+                '1 11 20 30 32',
+                '1', '0', '0', '0', '0', '0', '0', '0', '0', '0', '1', '0',
+                '0', '0', '0', '0', '0', '0', '0', '1', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '1', '0', '1', '0', '0', '0', '0',
+                '0', '0', '0', '0', '0', '0', '0', '0', '0', '0',
+            ],
+        ]
+        self.assertListEqual(
+            export['Literacy test']['data'],
+            expected_data
+        )


### PR DESCRIPTION
Support exporting data collected with https://github.com/kobotoolbox/enketo-literacy-test-widget, which uses a modified `select_multiple` question (with `appearance` set to `literacy`) that prepends special, non-choice parameters to the value.