### PR TITLE
Use Openpyxl for exports instead of PyExcelerate

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-coverage==4.0.3
+coverage==4.5.1
 nose==1.3.7
-tox==2.3.1
-flake8==2.5.4
+tox==2.9.1
+flake8==3.5.0
+pytest==3.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 begins==0.9
 cyordereddict==1.0.0
-jsonschema==2.5.1
-lxml==2.3.4
-path.py==8.1.2
-PyExcelerate==0.6.7
-pyquery==1.2.11
-pyxform==0.9.22
+jsonschema==2.6.0
+lxml==4.1.1
+path.py==10.5
+openpyxl==2.5.0
+pyquery==1.4.0
+pyxform==0.10.0
 statistics==1.0.3.5

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
 import re
+import sys
 from setuptools import setup, find_packages
 
 
@@ -35,6 +36,10 @@ def get_requirements(path):
 requirements, dep_links = get_requirements('requirements.txt')
 dev_requirements, dev_dep_links = get_requirements('dev-requirements.txt')
 
+if 'develop' in sys.argv:
+    requirements += dev_requirements
+    dep_links += dev_dep_links
+
 setup(name='formpack',
       version='1.4',
       description='Manipulation tools for kobocat forms',
@@ -44,9 +49,6 @@ setup(name='formpack',
       packages=[str(pkg) for pkg in find_packages('src')],
       package_dir={'': b'src'},
       install_requires=requirements,
-      extras_require={
-          'dev': dev_requirements
-      },
       include_package_data=True,
       zip_safe=False,
       )

--- a/src/formpack/constants.py
+++ b/src/formpack/constants.py
@@ -33,6 +33,9 @@ OR_OTHER_COLUMN = '_or_other'
 # http://stackoverflow.com/a/3681908
 EXCEL_SHEET_NAME_SIZE_LIMIT = 31
 
+# Some characters are forbidden from worksheet names
+EXCEL_FORBIDDEN_WORKSHEET_NAME_CHARACTERS = r'[]*?:\/'
+
 # Tag columns are tags that have their own columns when expanding and
 # flattening. Internally, they are stored as tags prefixed with their column
 # name and a colon, e.g.

--- a/src/formpack/utils/string.py
+++ b/src/formpack/utils/string.py
@@ -8,7 +8,9 @@ import re
 import unicodedata
 import string
 import random
-from ..constants import EXCEL_SHEET_NAME_SIZE_LIMIT
+from ..constants import (
+    EXCEL_SHEET_NAME_SIZE_LIMIT, EXCEL_FORBIDDEN_WORKSHEET_NAME_CHARACTERS
+)
 
 try:
     unicode = unicode
@@ -81,6 +83,8 @@ def unique_name_for_xls(sheet_name, other_sheet_names, base_ellipsis='...'):
     r"""
     Return a sheet name that does not collide with any string in the iterable
     `other_sheet_names` and does not exceed the Excel sheet name length limit.
+    Characters that are not allowed in sheet names are replaced with
+    underscores.
     :Example:
         >>> unique_name_for_xls(
         ...     'This string has more than 31 characters!',
@@ -88,6 +92,10 @@ def unique_name_for_xls(sheet_name, other_sheet_names, base_ellipsis='...'):
         ... )
         u'This string has more tha... (1)'
     """
+
+    sheet_name = sheet_name.translate({
+        ord(c): '_' for c in EXCEL_FORBIDDEN_WORKSHEET_NAME_CHARACTERS
+    })
 
     candidate = ellipsize(
         sheet_name, EXCEL_SHEET_NAME_SIZE_LIMIT, base_ellipsis)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1066,13 +1066,7 @@ class TestFormPackExport(unittest.TestCase):
             fp.export(**options).to_xlsx(xls, submissions)
             assert xls.isfile()
 
-    def test_xlsx_sheet_name_limit(self):
-        '''
-        PyExcelerate will raise the following if any sheet name exceeds 31
-        characters:
-            Exception: Excel does not permit worksheet names longer than 31
-            characters. Set force_name=True to disable this restriction.
-        '''
+    def test_xlsx_long_sheet_names_and_invalid_chars(self):
         title, schemas, submissions = build_fixture('long_names')
         fp = FormPack(schemas, title)
         options = {'versions': 'long_survey_name__the_quick__brown_fox_jumps'
@@ -1084,7 +1078,7 @@ class TestFormPackExport(unittest.TestCase):
             assert xls.isfile()
             book = xlrd.open_workbook(xls)
             assert book.sheet_names() == [
-                u'long survey name: the quick,...',
+                u'long survey name_ the quick,...',
                 u'long_group_name__Victor_jagt...',
                 u'long_group_name__Victor_... (1)'
             ]


### PR DESCRIPTION
and tame dependencies in general (updates, conflict resolution). Running `python setup.py develop` now actually installs what's in `dev-requirements.txt`.

Fixes #155.