### PR TITLE
Fixed missing item in percentage list when stats are disaggregated

### DIFF
--- a/tests/fixtures/auto_report_extended_fields/__init__.py
+++ b/tests/fixtures/auto_report_extended_fields/__init__.py
@@ -1,0 +1,15 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+
+from ..load_fixture_json import load_fixture_json
+
+DATA = {
+    u'title': 'Auto report with extended fields',
+    u'id_string': 'auto_report_extended_fields',
+    u'versions': [
+        load_fixture_json('auto_report_extended_fields/v1')
+    ],
+}

--- a/tests/fixtures/auto_report_extended_fields/v1.json
+++ b/tests/fixtures/auto_report_extended_fields/v1.json
@@ -1,0 +1,167 @@
+{
+    "id_string": "auto_report",
+    "version": "rpfrv2",
+    "content": {
+        "survey": [
+            {
+                "type": "text",
+                "name": "restaurant_name",
+                "label": "Restaurant name"
+            },
+            {
+                "type": "select_one restaurant_type",
+                "name": "restaurant_type",
+                "label": "Type of restaurant"
+            },
+            {
+                "type": "date",
+                "name": "when",
+                "label": "When"
+            }
+        ],
+        "choices": [
+            {
+                "list_name": "restaurant_type",
+                "name": "italian",
+                "label": "Italian"
+            },
+            {
+                "list_name": "restaurant_type",
+                "name": "french",
+                "label": "French"
+            },
+            {
+                "list_name": "restaurant_type",
+                "name": "vietnamese",
+                "label": "Vietnamese"
+            },
+            {
+                "list_name": "restaurant_type",
+                "name": "chinese",
+                "label": "Chinese"
+            },
+            {
+                "list_name": "restaurant_type",
+                "name": "thai",
+                "label": "Thai"
+            },
+            {
+                "list_name": "restaurant_type",
+                "name": "american",
+                "label": "American"
+            }
+        ]
+    },
+    "submissions": [
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-01"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-01"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-01"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-02"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-02"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-02"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-03"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-03"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-05"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-05"
+        },
+        {
+            "restaurant_name": "Chez Céline",
+            "restaurant_type": "french",
+            "when": "2001-01-06"
+        },
+        {
+            "restaurant_name": "Po Thaï",
+            "restaurant_type": "thai",
+            "when": "2001-01-01"
+        },
+        {
+            "restaurant_name": "Po Thaï",
+            "restaurant_type": "thai",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Po Thaï",
+            "restaurant_type": "thai",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "La Bodega",
+            "restaurant_type": "italian",
+            "when": "2001-01-05"
+        },
+        {
+            "restaurant_name": "La Bodega",
+            "restaurant_type": "italian",
+            "when": "2001-01-02"
+        },
+        {
+            "restaurant_name": "Mc Donalds",
+            "restaurant_type": "american",
+            "when": "2001-01-04"
+        },
+        {
+            "restaurant_name": "Beijing Express",
+            "restaurant_type": "chinese",
+            "when": "2001-01-01"
+        }
+    ]
+}

--- a/tests/test_autoreport.py
+++ b/tests/test_autoreport.py
@@ -371,10 +371,14 @@ class TestAutoReport(unittest.TestCase):
 
         assert stats.submissions_count == 22
 
-        stats = [(unicode(repr(f)), n, d) for f, n, d in stats]
+        stats = [(unicode(repr(field)), field_name, stats_dict) for field, field_name, stats_dict in stats]
 
         for stat in stats:
-            dict_values = dict(stat[2])
-            for value in dict_values.get("values"):
+            stats_dict = dict(stat[2])
+            for value in stats_dict.get("values"):
                 value_list = value[1]
-                assert len(value_list.get("percentage")) == len(value_list.get("frequency"))
+                percentage_responses = [x[0] for x in value_list.get("percentage")]
+                frequency_responses = [x[0] for x in value_list.get("frequency")]
+                assert percentage_responses == frequency_responses
+                assert percentage_responses[-1] == "..."
+

--- a/tests/test_autoreport.py
+++ b/tests/test_autoreport.py
@@ -296,6 +296,7 @@ class TestAutoReport(unittest.TestCase):
     def test_disaggregate(self):
 
         title, schemas, submissions = build_fixture('auto_report')
+
         fp = FormPack(schemas, title)
 
         report = fp.autoreport()
@@ -359,3 +360,21 @@ class TestAutoReport(unittest.TestCase):
                                    'stdev': u'*'}))})]
         for (i, stat) in enumerate(stats):
             assert stat == expected[i]
+
+    def test_disaggregate_extended_fields(self):
+
+        title, schemas, submissions = build_fixture('auto_report_extended_fields')
+        fp = FormPack(schemas, title)
+
+        report = fp.autoreport()
+        stats = report.get_stats(submissions, split_by="when")
+
+        assert stats.submissions_count == 22
+
+        stats = [(unicode(repr(f)), n, d) for f, n, d in stats]
+
+        for stat in stats:
+            dict_values = dict(stat[2])
+            for value in dict_values.get("values"):
+                value_list = value[1]
+                assert len(value_list.get("percentage")) == len(value_list.get("frequency"))


### PR DESCRIPTION
This error occurred when stats were disaggregated in more than 5 items. 
We don't return more than 5 items, all others are grouped and displayed under an `ellipsis` label.
But data was grouped only in the `frequency` list, not the `percentage` one.

I have also added a simple test which validates that both lists have the same length when stats are disaggregated with more than 5 items.