### PR TITLE
Escape `quote` during CSV exports by doubling it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: python
 python:
   - "2.7"
 install:
-  - "pip install funcsigs"
-  - "pip install pytest pytest-cov python-coveralls"
   - "python setup.py develop"
 script:
   - "py.test tests --cov=src -vv"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,12 @@ language: python
 python:
   - "2.7"
 install:
+  # Get rid of Travis' pytest 3.3.0, which somehow persists even though our
+  # requirements pin a newer version!
+  - "pip uninstall --yes pytest"
   - "python setup.py develop"
 script:
+  - "pip freeze"
   - "pytest tests --cov=src -vv"
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ python:
 install:
   - "python setup.py develop"
 script:
-  - "py.test tests --cov=src -vv"
+  - "pytest tests --cov=src -vv"
 after_success:
   - coveralls

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
-coverage==4.5.1
+coverage==4.5.2
 nose==1.3.7
-tox==2.9.1
-flake8==3.5.0
-pytest==3.4.0
+tox==3.7.0
+flake8==3.6.0
+pytest==4.1.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,4 @@ flake8==3.6.0
 pytest==4.1.1
 funcsigs==1.0.2
 pytest-cov==2.6.1
-python-coveralls==2.9.1
+coveralls==1.5.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,3 +3,6 @@ nose==1.3.7
 tox==3.7.0
 flake8==3.6.0
 pytest==4.1.1
+funcsigs==1.0.2
+pytest-cov==2.6.1
+python-coveralls==2.9.1

--- a/src/formpack/reporting/export.py
+++ b/src/formpack/reporting/export.py
@@ -427,8 +427,22 @@ class Export(object):
         # if len(sections) > 1:
         #     raise RuntimeError("CSV export does not support repeatable groups")
 
+        def escape_quote(value, quote):
+            '''
+                According to https://www.ietf.org/rfc/rfc4180.txt,
+
+                    If double-quotes are used to enclose fields, then a
+                    double-quote appearing inside a field must be escaped by
+                    preceding it with another double quote.
+
+                We will follow this convention by doubling `quote` wherever it
+                appears in `value`, regardless of what `quote` is. Perhaps this
+                is not the best idea.
+            '''
+            return value.replace(quote, quote * 2)
+
         def format_line(line, sep, quote):
-            line = [unicode(x) for x in line]
+            line = [escape_quote(unicode(x), quote) for x in line]
             return quote + (quote + sep + quote).join(line) + quote
 
         section, labels = sections[0]

--- a/tests/fixtures/quotes_newlines_and_long_urls/__init__.py
+++ b/tests/fixtures/quotes_newlines_and_long_urls/__init__.py
@@ -1,0 +1,101 @@
+# coding: utf-8
+
+from __future__ import (unicode_literals, print_function,
+                        absolute_import, division)
+
+'''
+Quotes, newlines, and long URLs: oh, my!
+
+Double quotation marks need to be escaped (by doubling them!) in CSV exports,
+    e.g. `Introduce excerpts with "` would become `Introduce excerpts with ""`.
+
+Excel does not tolerate hyperlinks with URLs longer than 255 characters. Not
+that we ever explicitly create Excel hyperlinks, but
+https://github.com/jmcnamara/XlsxWriter tries to be helpful and add them
+automatically. Excessively long URLs should just be written as strings.
+'''
+
+DATA = {
+    'title': 'Quotes, newlines, and long URLs',
+    'id_string': 'quotes_newlines_and_long_urls',
+    'versions': [
+        {
+            "version": "first",
+            "content": {
+                "choices": [
+                    {
+                        "label": ["yes"],
+                        "list_name": "yes_no",
+                        "name": "yes",
+                    },
+                    {
+                        "label": ["no"],
+                        "list_name": "yes_no",
+                        "name": "no",
+                    },
+                ],
+                "survey": [
+                    {
+                        "required": False,
+                        "appearance": "multiline",
+                        "name": "Enter_some_long_text_and_linebreaks_here",
+                        "label": [
+                            "Enter some long text with \" and linebreaks here"
+                        ],
+                        "type": "text",
+                    },
+                    {
+                        "select_from_list_name": "yes_no",
+                        "required": False,
+                        "name": "Some_other_question",
+                        "label": ["Some other question"],
+                        "type": "select_one",
+                    },
+                ],
+            },
+            'submissions': [
+                {
+                    "Enter_some_long_text_and_linebreaks_here":
+                        "Check out this URL I found:\n"
+                        "https://now.read.this/?Never%20forget%20that%20you%20"
+                        "are%20one%20of%20a%20kind.%20Never%20forget%20that%20"
+                        "if%20there%20weren%27t%20any%20need%20for%20you%20in"
+                        "%20all%20your%20uniqueness%20to%20be%20on%20this%20"
+                        "earth%2C%20you%20wouldn%27t%20be%20here%20in%20the%20"
+                        "first%20place.%20And%20never%20forget%2C%20no%20"
+                        "matter%20how%20overwhelming%20life%27s%20challenges"
+                        "%20and%20problems%20seem%20to%20be%2C%20that%20one%20"
+                        "person%20can%20make%20a%20difference%20in%20the%20"
+                        "world.%20In%20fact%2C%20it%20is%20always%20because%20"
+                        "of%20one%20person%20that%20all%20the%20changes%20that"
+                        "%20matter%20in%20the%20world%20come%20about.%20So%20"
+                        "be%20that%20one%20person.",
+                    "Some_other_question": "yes",
+                },
+                # Thanks to @tinok for the whimisical sample data below
+                {
+                    "Enter_some_long_text_and_linebreaks_here":
+                        "Hi, my name is Roger.\"\n\nI like to enter quotes "
+                        "randomly and follow them with new lines.",
+                    "Some_other_question": "yes",
+                },
+                {
+                    "Enter_some_long_text_and_linebreaks_here":
+                        "This one has no linebreaks",
+                    "Some_other_question": "no",
+                },
+                {
+                    "Enter_some_long_text_and_linebreaks_here":
+                        "This\nis\nnot\na Haiku",
+                    "Some_other_question": "yes",
+                },
+                {
+                    "Enter_some_long_text_and_linebreaks_here":
+                        "\"Hands up!\" He yelled.\nWhy?\"\nShe couldn't "
+                        "understand anything.",
+                    "Some_other_question": "yes",
+                },
+            ],
+        },
+    ],
+}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1107,6 +1107,43 @@ class TestFormPackExport(unittest.TestCase):
 
         self.assertTextEqual(csv_data, expected)
 
+    def test_csv_quote_escaping(self):
+        title, schemas, submissions = build_fixture(
+            'quotes_newlines_and_long_urls')
+        fp = FormPack(schemas, title)
+        lss = list(submissions)
+        csv_lines = list(fp.export().to_csv(submissions))
+        expected_lines = []
+        expected_lines.append(
+            '"Enter_some_long_text_and_linebreaks_here";'
+            '"Some_other_question"'
+        )
+        expected_lines.append(
+            '"Check out this URL I found:\nhttps://now.read.this/?Never%20forg'
+            'et%20that%20you%20are%20one%20of%20a%20kind.%20Never%20forget%20t'
+            'hat%20if%20there%20weren%27t%20any%20need%20for%20you%20in%20all%'
+            '20your%20uniqueness%20to%20be%20on%20this%20earth%2C%20you%20woul'
+            'dn%27t%20be%20here%20in%20the%20first%20place.%20And%20never%20fo'
+            'rget%2C%20no%20matter%20how%20overwhelming%20life%27s%20challenge'
+            's%20and%20problems%20seem%20to%20be%2C%20that%20one%20person%20ca'
+            'n%20make%20a%20difference%20in%20the%20world.%20In%20fact%2C%20it'
+            '%20is%20always%20because%20of%20one%20person%20that%20all%20the%2'
+            '0changes%20that%20matter%20in%20the%20world%20come%20about.%20So%'
+            '20be%20that%20one%20person.";"yes"'
+        )
+        expected_lines.append(
+            '"Hi, my name is Roger.""\n\nI like to enter quotes randomly and '
+            'follow them with new lines.";"yes"'
+        )
+        expected_lines.append('"This one has no linebreaks";"no"')
+        expected_lines.append('"This\nis\nnot\na Haiku";"yes"')
+        expected_lines.append(
+            '"""Hands up!"" He yelled.\nWhy?""\n'
+            '''She couldn't understand anything.";"yes"'''
+        )
+
+        self.assertListEqual(csv_lines, expected_lines)
+
     def test_csv_with_tag_headers(self):
         title, schemas, submissions = build_fixture('dietary_needs')
         fp = FormPack(schemas, title)


### PR DESCRIPTION
Fixes #193. The long URL in the new test fixture is for the next bug that needs to be fixed :wink: 