### PR TITLE
Revert "Work around XLSForm/pyxform#236 by converting"

### DIFF
--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -224,13 +224,3 @@ def _flatten_survey_row(row):
                 row['type'] = '{} {} or_other'.format(_type, _list_name)
             else:
                 row['type'] = '{} {}'.format(_type, _list_name)
-
-    # TODO: remove this once https://github.com/XLSForm/pyxform/issues/236 is
-    # fixed?
-    try:
-        _order = row['order']
-    except KeyError:
-        pass
-    else:
-        if not isinstance(_order, basestring):
-            row['order'] = '{}'.format(_order)


### PR DESCRIPTION
Reverts kobotoolbox/formpack#180, which isn't needed now that XLSForm/pyxform#237 has been merged.