### PR TITLE
Improve packaging and update dev. instructions:

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
   # Get rid of Travis' pytest 3.3.0, which somehow persists even though our
   # requirements pin a newer version!
   - "pip uninstall --yes pytest"
-  - "python setup.py develop"
+  - "pip install -r dev-requirements.txt"
 script:
   - "pytest tests --cov=src -vv"
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,8 @@ language: python
 python:
   - "2.7"
 install:
-  # Get rid of Travis' pytest 3.3.0, which somehow persists even though our
-  # requirements pin a newer version!
-  - "pip uninstall --yes pytest"
+  - "virtualenv e"
+  - "source e/bin/activate"
   - "pip install -r dev-requirements.txt"
 script:
   - "pytest tests --cov=src -vv"

--- a/README.rst
+++ b/README.rst
@@ -12,11 +12,16 @@ Setup
 Install::
 
     python setup.py install
-    # or develop the code: python setup.py develop
+
+Develop::
+
+    # Create and activate a new virtualenv, then:
+    pip install -r dev-requirements.txt
 
 Test::
 
-    tox
+    # Within a development environment, as described above:
+    pytest
 
 Command line methods::
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,13 @@
+# This file is used for testing and development. See
+# https://caremad.io/posts/2013/07/setup-vs-requirement/
+
+# It doesn't seem like pip honors `dependency_links` in setup.py, so install
+# any forked packages here first.
+
+# Install this package
+-e .
+
+# Install testing / development requirements
 coverage==4.5.2
 nose==1.3.7
 tox==3.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,0 @@
-begins==0.9
-cyordereddict==1.0.0
-jsonschema==2.6.0
-lxml==4.3.0
-path.py==11.5.0
-pyquery==1.4.0
-pyxform==0.13.1
-statistics==1.0.3.5
-XlsxWriter==1.1.2

--- a/setup.py
+++ b/setup.py
@@ -9,36 +9,23 @@ import sys
 from setuptools import setup, find_packages
 
 
-def get_requirements(path):
-
-    setuppy_format = \
-        'https://github.com/{user}/{repo}/tarball/master#egg={egg}'
-
-    setuppy_pattern = \
-        r'github.com/(?P<user>[^/.]+)/(?P<repo>[^.]+).git#egg=(?P<egg>.+)'
-
-    dep_links = []
-    install_requires = []
-    with open(path) as f:
-        for line in f:
-
-            if line.startswith('-e'):
-                url_infos = re.search(setuppy_pattern, line).groupdict()
-                dep_links.append(setuppy_format.format(**url_infos))
-                egg_name = '=='.join(url_infos['egg'].rsplit('-', 1))
-                install_requires.append(egg_name)
-            else:
-                install_requires.append(line.strip())
-
-    return install_requires, dep_links
-
-
-requirements, dep_links = get_requirements('requirements.txt')
-dev_requirements, dev_dep_links = get_requirements('dev-requirements.txt')
-
-if 'develop' in sys.argv:
-    requirements += dev_requirements
-    dep_links += dev_dep_links
+requirements = [
+    'begins',
+    'cyordereddict',
+    'jsonschema',
+    'lxml',
+    'path.py<12', # Pinned for Python 2 compatibility
+    'pyquery',
+    'pyxform',
+    'statistics',
+    'XlsxWriter',
+]
+dep_links = [
+    # "Be careful with the version" part of `#egg=project-version`, according to
+    # https://setuptools.readthedocs.io/en/latest/setuptools.html#dependencies-that-aren-t-in-pypi.
+    # "It should match the one inside the project files," i.e. the `version`
+    # argument to `setup()` in `setup.py`. It should also adhere to PEP 440.
+]
 
 setup(name='formpack',
       version='1.4',
@@ -49,6 +36,7 @@ setup(name='formpack',
       packages=[str(pkg) for pkg in find_packages('src')],
       package_dir={'': b'src'},
       install_requires=requirements,
+      dependency_links=dep_links,
       include_package_data=True,
       zip_safe=False,
       )


### PR DESCRIPTION
* Use abstract dependencies in `setup.py`;
* Remove `requirements.txt`;
* Use `-e .` in dev-requirements.txt;
* Instruct developers to use `pip install` instead of `setup.py develop`.