### PR TITLE
Added Python 3 support for "unichr"

### DIFF
--- a/src/formpack/utils/future.py
+++ b/src/formpack/utils/future.py
@@ -17,6 +17,12 @@ try:
 except NameError:
     range = range
 
+
+try:
+    unichr = unichr
+except NameError:
+    unichr = chr
+
 import sys
 
 # These helpers are duplicated from `six`.
@@ -37,4 +43,3 @@ def itervalues(d, **kw):
         return d.itervalues(**kw)
     else:
         return iter(d.values(**kw))
-

--- a/src/formpack/utils/xls_to_ss_structure.py
+++ b/src/formpack/utils/xls_to_ss_structure.py
@@ -6,7 +6,7 @@ import datetime
 import re
 import xlrd
 
-from .future import OrderedDict
+from .future import OrderedDict, unichr
 from .string import unicode, str_types
 
 


### PR DESCRIPTION
`unichr` doesn't exist in Python3. 
Allow `unichr` usage with Python 2 and Python 3.

To be removed when Python 2 support is dropped.