### PR TITLE
ignore questions specified to be ignored

### DIFF
--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -11,7 +11,9 @@ from .utils.flatten_content import flatten_content
 from .utils.future import OrderedDict
 from .utils.xform_tools import formversion_pyxform
 from .validators import validate_content
+from pyxform import aliases as pyxform_aliases
 
+YES_NO = pyxform_aliases.yes_no
 
 class LabelStruct(object):
     """
@@ -176,6 +178,10 @@ class FormVersion(object):
                 section_stack.append(parent_section)
                 parent_section.children.append(section)
                 continue
+
+            if 'disabled' in data_definition:
+                if YES_NO.get(str(data_definition['disabled']), False):
+                    continue
 
             # If we are here, it's a regular field
             # Get the the data name and type

--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -120,6 +120,10 @@ class FormVersion(object):
         section_stack = []
 
         for data_definition in survey:
+            if 'disabled' in data_definition:
+                if YES_NO.get(str(data_definition['disabled']), False):
+                    continue
+
             data_type = data_definition.get('type')
             if not data_type:  # handle broken data type definition
                 continue
@@ -178,10 +182,6 @@ class FormVersion(object):
                 section_stack.append(parent_section)
                 parent_section.children.append(section)
                 continue
-
-            if 'disabled' in data_definition:
-                if YES_NO.get(str(data_definition['disabled']), False):
-                    continue
 
             # If we are here, it's a regular field
             # Get the the data name and type

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -60,6 +60,7 @@ def test_to_xml_fails_when_null_labels():
                    }}, id_string='sdf')
     fp[0].to_xml()
 
+from formpack.schema.datadef import FormGroup
 
 def test_groups_disabled():
     scontent = {'content': {
@@ -82,21 +83,20 @@ def test_groups_disabled():
 
     # verify values before setting "disabled=TRUE"
     fp = FormPack(scontent, id_string='xx')
-    ss = [ss for ss in fp[0].sections.values()][0]
+    section = next(iter(fp[0].sections.values()))
     # only(?) way to access groups is in the hierarchy of a child question
-    n2_parent = ss.fields['n2'].hierarchy[-2]
-    group_class_repr = "<class 'formpack.schema.datadef.FormGroup'>"
-    assert repr(n2_parent.__class__) == group_class_repr
+    n2_parent = section.fields['n2'].hierarchy[-2]
+    assert isinstance(n2_parent, FormGroup)
     assert n2_parent.name == 'nada'
     assert 'nada' in fp[0].to_xml()
 
     ga['disabled'] = gz['disabled'] = 'TRUE'
     fp = FormPack(scontent, id_string='xx')
-    ss = [ss for ss in fp[0].sections.values()][0]
-    n2_parent = ss.fields['n2'].hierarchy[-2]
+    section = next(iter(fp[0].sections.values()))
+    n2_parent = section.fields['n2'].hierarchy[-2]
     # n2_parent is a "<FormSection name='submissions'>"
     # test opposite of what's tested above--
-    assert repr(n2_parent.__class__) != group_class_repr
+    assert not isinstance(n2_parent, FormGroup)
     assert n2_parent.name != 'nada'
     assert 'nada' not in fp[0].to_xml()
 

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -5,6 +5,8 @@ from __future__ import (unicode_literals, print_function,
 import json
 from copy import deepcopy
 
+from nose.tools import raises
+
 from formpack import FormPack, constants
 from formpack.utils.iterator import get_first_occurrence
 from .fixtures import build_fixture
@@ -91,6 +93,36 @@ def test_disabled_questions_ignored():
     fp = FormPack(scontent, id_string='xx')
     s1_fields = [ss for ss in fp[0].sections.values()][0].fields
     assert 'q2' in s1_fields
+
+
+@raises(KeyError)
+def test_missing_choice_list_breaks():
+    scontent = {'content': {
+                   'survey': [
+                              {'type': 'select_one dogs', 'name': 'q1',
+                               'label': ['aa']},
+                              ],
+                   'translations': ['en'],
+                   'translated': ['label'],
+                  }
+                }
+    q1 = scontent['content']['survey'][0]
+    fp = FormPack(scontent, id_string='xx')
+
+
+def test_commented_out_missing_choice_list_does_not_break():
+    scontent = {'content': {
+                   'survey': [
+                              {'type': 'select_one dogs', 'name': 'q1',
+                               'disabled': 'TRUE',
+                               'label': ['aa']},
+                              ],
+                   'translations': ['en'],
+                   'translated': ['label'],
+                  }
+                }
+    q1 = scontent['content']['survey'][0]
+    fp = FormPack(scontent, id_string='xx')
 
 
 def test_null_untranslated_labels():

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -60,6 +60,23 @@ def test_to_xml_fails_when_null_labels():
                    }}, id_string='sdf')
     fp[0].to_xml()
 
+def test_groups_disabled():
+    scontent = {'content': {
+                   'survey': [
+                              {'type': 'text','name': 'n1', 'label': ['aa']},
+                              {'type': 'begin_group', 'name': 'nada', 'disabled': 'TRUE'},
+                              {'type': 'note', 'name': 'n2', 'label': ['ab']},
+                              {'type': 'end_group', 'disabled': 'TRUE'},
+                              ],
+                   'translations': ['en'],
+                   'translated': ['label'],
+                  }
+                }
+    fp = FormPack(scontent, id_string='xx')
+    ss = [ss for ss in fp[0].sections.values()][0]
+    gg = ss.fields['n2'].hierarchy[1]
+    xml = fp[0].to_xml()
+    assert 'nada' not in xml
 
 def test_disabled_questions_ignored():
     scontent = {'content': {
@@ -72,24 +89,23 @@ def test_disabled_questions_ignored():
                    'translated': ['label'],
                   }
                 }
-    q1 = scontent['content']['survey'][1]
+    qq = scontent['content']['survey'][1]
 
     fp = FormPack(scontent, id_string='xx')
     s1_fields = [ss for ss in fp[0].sections.values()][0].fields
     assert 'q2' in s1_fields
 
-    q1['disabled'] = True
+    qq['disabled'] = True
     fp = FormPack(scontent, id_string='xx')
     s1_fields = [ss for ss in fp[0].sections.values()][0].fields
     assert 'q2' not in s1_fields
 
-
-    q1['disabled'] = 'true'
+    qq['disabled'] = 'true'
     fp = FormPack(scontent, id_string='xx')
     s1_fields = [ss for ss in fp[0].sections.values()][0].fields
     assert 'q2' not in s1_fields
 
-    q1['disabled'] = 'FALSE'
+    qq['disabled'] = 'FALSE'
     fp = FormPack(scontent, id_string='xx')
     s1_fields = [ss for ss in fp[0].sections.values()][0].fields
     assert 'q2' in s1_fields
@@ -106,7 +122,6 @@ def test_missing_choice_list_breaks():
                    'translated': ['label'],
                   }
                 }
-    q1 = scontent['content']['survey'][0]
     fp = FormPack(scontent, id_string='xx')
 
 
@@ -121,7 +136,6 @@ def test_commented_out_missing_choice_list_does_not_break():
                    'translated': ['label'],
                   }
                 }
-    q1 = scontent['content']['survey'][0]
     fp = FormPack(scontent, id_string='xx')
 
 

--- a/tests/test_formpack_internals.py
+++ b/tests/test_formpack_internals.py
@@ -59,6 +59,40 @@ def test_to_xml_fails_when_null_labels():
     fp[0].to_xml()
 
 
+def test_disabled_questions_ignored():
+    scontent = {'content': {
+                   'survey': [
+                              {'type': 'note', 'name': 'n1', 'label': ['aa']},
+                              {'type': 'text','name': 'q2', 'label': ['bb'],
+                               }
+                              ],
+                   'translations': ['en'],
+                   'translated': ['label'],
+                  }
+                }
+    q1 = scontent['content']['survey'][1]
+
+    fp = FormPack(scontent, id_string='xx')
+    s1_fields = [ss for ss in fp[0].sections.values()][0].fields
+    assert 'q2' in s1_fields
+
+    q1['disabled'] = True
+    fp = FormPack(scontent, id_string='xx')
+    s1_fields = [ss for ss in fp[0].sections.values()][0].fields
+    assert 'q2' not in s1_fields
+
+
+    q1['disabled'] = 'true'
+    fp = FormPack(scontent, id_string='xx')
+    s1_fields = [ss for ss in fp[0].sections.values()][0].fields
+    assert 'q2' not in s1_fields
+
+    q1['disabled'] = 'FALSE'
+    fp = FormPack(scontent, id_string='xx')
+    s1_fields = [ss for ss in fp[0].sections.values()][0].fields
+    assert 'q2' in s1_fields
+
+
 def test_null_untranslated_labels():
     content = json.loads('''
         {


### PR DESCRIPTION
* pyxform has an undocumented way to ignore questions from surveys (`disabled=TRUE`)
* surveys were being deployed in KPI which had questions with this attribute
* exports were breaking because formpack was looking for choice lists that didn't exist because the questions were "commented out"

fixes #219 