### PR TITLE
Add utility function that returns a single mode

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -10,6 +10,7 @@ import statistics
 
 from .datadef import FormDataDef, FormChoice
 from ..constants import UNSPECIFIED_TRANSLATION
+from ..utils import singlemode
 from ..utils.future import range, OrderedDict
 from ..utils.ordered_collection import OrderedDefaultdict
 
@@ -447,7 +448,7 @@ class NumField(FormField):
             stats['stdev'] = statistics.stdev(self.flatten_dataset(metrics),
                                               xbar=stats['mean'])
             # requires a non empty dataset and a unique mode
-            stats['mode'] = statistics.mode(self.flatten_dataset(metrics))
+            stats['mode'] = singlemode(self.flatten_dataset(metrics))
         except statistics.StatisticsError:
             pass
 
@@ -489,7 +490,7 @@ class NumField(FormField):
                 val_stats['stdev'] = statistics.stdev(values,
                                                       xbar=val_stats['mean'])
                 # requires a non empty dataset and a unique mode
-                val_stats['mode'] = statistics.mode(values)
+                val_stats['mode'] = singlemode(values)
             except statistics.StatisticsError:
                 pass
 

--- a/src/formpack/utils/__init__.py
+++ b/src/formpack/utils/__init__.py
@@ -2,6 +2,7 @@
 from __future__ import (unicode_literals, print_function,
                         absolute_import, division)
 
+from .statistics import singlemode  # noqa
 from .string import slugify, randstr, str_types, unique_name_for_xls  # noqa
 from .xform_tools import (parse_xmljson_to_data,
                           parse_xml_to_xmljson,

--- a/src/formpack/utils/statistics.py
+++ b/src/formpack/utils/statistics.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+import statistics
+
+
+def singlemode(data):
+    try:
+        # New in Python 3.8
+        modes = statistics.multimode(data)
+    except AttributeError:
+        return statistics.mode(data)
+    else:
+        if len(modes) > 1:
+            raise statistics.StatisticsError('no unique mode')
+        else:
+            return modes[0]


### PR DESCRIPTION
Python 3.8 changed the behavior of `mode()` to return the first mode if
no unique mode exists: https://bugs.python.org/issue35892#msg336570.
This returns to the old behavior where an exception is raised if there's
no unique mode