### PR TITLE
Omit empty group labels when generating XML

### DIFF
--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -149,7 +149,7 @@ def translated_col_list(columns, translations, translated):
 
 def _flatten_translated_fields(row, translations, translated_cols,
                                col_order=False,
-                               strip_null_vals_from_named_translations=True,
+                               strip_empty_vals_from_named_translations=True,
                                ):
     if len(translations) == 0:
         translations = [UNTRANSLATED]
@@ -198,8 +198,13 @@ def _flatten_translated_fields(row, translations, translated_cols,
                 _place_col_in_order(key)
             else:
                 _built_colname = '{}::{}'.format(key, _t)
-                if (value is None) and strip_null_vals_from_named_translations:
-                    value = ''
+                if strip_empty_vals_from_named_translations and (
+                    value is None or value == ''
+                ):
+                    # is there a case where we'd want to change None to an
+                    # empty string instead of skipping it entirely? see commit
+                    # 42e8766
+                    continue
                 row[_built_colname] = value
                 _place_col_in_order(_built_colname, key)
     _placed_cols.update(row.keys())


### PR DESCRIPTION
Goal: make formpack-to-XML conversion behave the same way as
formpack-to-XLSForm-to-XML conversion. The better those match, the
better KPI's previews will match its deployed forms.

In this particular case, pyxform discarded empty cells when loading from
XLSForm, but formpack was preserving empty strings when sending Python
structures to pyxform for conversion to XML. One consequence of this was
empty translated labels being shown for groups in KPI previews, i.e.
kobotoolbox/kpi#2707.