### PR TITLE
Fix `multiple_select` export option

### DIFF
--- a/src/formpack/reporting/export.py
+++ b/src/formpack/reporting/export.py
@@ -250,16 +250,17 @@ class Export(object):
             name_lists = []
             tags = []
             for field in fields:
-                name_lists.append(
-                    field.get_value_names(multiple_select=self.multiple_select)
+                value_names = field.get_value_names(
+                    multiple_select=self.multiple_select
                 )
+                name_lists.append(value_names)
 
                 # Add the tags for this field. If the field has multiple
                 # labels, add the tag for the first label *only*. Insert blanks
                 # for the subsequent fields. See
                 # https://github.com/kobotoolbox/formpack/issues/208
                 tags.extend([flatten_tag_list(field.tags, tag_cols_and_seps)])
-                tags.extend([{}] * (len(field.get_value_names()) - 1))
+                tags.extend([{}] * (len(value_names) - 1))
 
             names = [name for name_list in name_lists for name in name_list]
 

--- a/src/formpack/schema/datadef.py
+++ b/src/formpack/schema/datadef.py
@@ -13,7 +13,6 @@ class FormDataDef(object):
     def __init__(self, name, labels=None, has_stats=False, *args, **kwargs):
         self.name = name
         self.labels = labels or {}
-        self.value_names = self.get_value_names()
         self.has_stats = has_stats
 
     def __repr__(self):

--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -38,8 +38,6 @@ class FormField(FormDataDef):
         else:
             self.has_stats = data_type != "note"
 
-        self.empty_result = self.format('', lang=UNSPECIFIED_TRANSLATION)
-
         # do not include the root section in the path
         self.path = '/'.join(info.name for info in self.hierarchy[1:])
 
@@ -53,6 +51,9 @@ class FormField(FormDataDef):
         """
         args = lang, group_sep, hierarchy_in_labels, multiple_select
         return [self._get_label(*args)]
+
+    def get_value_names(self, multiple_select="both"):
+        return super().get_value_names()
 
     def get_translation(self, val, lang=UNSPECIFIED_TRANSLATION):
         """
@@ -193,7 +194,11 @@ class FormField(FormDataDef):
 
         return data_type_classes.get(data_type, cls)(**args)
 
-    def format(self, val, lang=UNSPECIFIED_TRANSLATION, context=None):
+    def format(
+        self, val, lang=UNSPECIFIED_TRANSLATION, context=None, *args, **kwargs
+    ):
+        if val is None:
+            val = ''
         return {self.name: val}
 
     def get_stats(self, metrics, lang=UNSPECIFIED_TRANSLATION, limit=100):
@@ -535,7 +540,9 @@ class ValidationStatusCopyField(CopyField):
             section=section,
             *args, **kwargs)
 
-    def format(self, val, lang=UNSPECIFIED_TRANSLATION, context=None):
+    def format(
+        self, val, lang=UNSPECIFIED_TRANSLATION, context=None, *args, **kwargs
+    ):
 
         if isinstance(val, dict):
             if lang == UNSPECIFIED_TRANSLATION:
@@ -620,11 +627,14 @@ class FormGPSField(FormField):
 
         """
 
+        if val is None:
+            val = ''
+
         values = [val, "", "", "", ""]
         for i, value in enumerate(val.split(), 1):
             values[i] = value
 
-        return dict(zip(self.value_names, values))
+        return dict(zip(self.get_value_names(), values))
 
 
 class FormChoiceField(ExtendedFormField):
@@ -649,6 +659,8 @@ class FormChoiceField(ExtendedFormField):
             return translation
 
     def format(self, val, lang=UNSPECIFIED_TRANSLATION, multiple_select="both"):
+        if val is None:
+            val = ''
         val = self.get_translation(val, lang)
         return {self.name: val}
 
@@ -707,26 +719,9 @@ class FormChoiceField(ExtendedFormField):
         combined_options.update(self.choice.options)
         self.choice.options = combined_options
 
-        self._empty_result()
-        self.value_names = self.get_value_names()
-
-    def _empty_result(self):
-        """
-        Nothing to do here
-        """
-        pass
-
 
 class FormChoiceFieldWithMultipleSelect(FormChoiceField):
     """  Same as FormChoiceField, but you can select several answer """
-
-    def __init__(self, *args, **kwargs):
-        super(FormChoiceFieldWithMultipleSelect, self).__init__(*args, **kwargs)
-        self._empty_result()
-
-    def _empty_result(self):
-        # reset empty result so it doesn't contain '0'
-        self.empty_result = dict.fromkeys(self.empty_result, '')
 
     def _get_option_label(self, lang=UNSPECIFIED_TRANSLATION, group_sep='/',
                           hierarchy_in_labels=False, option=None):
@@ -786,11 +781,23 @@ class FormChoiceFieldWithMultipleSelect(FormChoiceField):
                 "summary": only the summary column
                 "details": only the details column
         """
-        cells = dict.fromkeys(self.value_names, "0")
+        if val is None:
+            # If the value is missing, do not imply that any response was
+            # received: fill with empty strings instead of zeros
+            return dict.fromkeys(
+                self.get_value_names(multiple_select=multiple_select), ""
+            )
+
+        cells = dict.fromkeys(
+            self.get_value_names(multiple_select=multiple_select), "0"
+        )
         if multiple_select in ("both", "summary"):
             res = []
             for v in val.split():
-                label = self.choice.options[v]['labels'].get(lang)
+                try:
+                    label = self.choice.options[v]['labels'][lang]
+                except KeyError:
+                    label = None
                 if label:
                     res.append(label)
                 else:
@@ -867,6 +874,8 @@ class FormLiteracyTestField(FormChoiceFieldWithMultipleSelect):
         return self.parameter_value_names + word_value_names
 
     def format(self, val, *args, **kwargs):
+        if val is None:
+            val = ''
         all_values = val.split()
         prepended_cells = dict(zip(self.parameter_value_names, all_values))
         word_values = all_values[len(self.PREPENDED_PARAMETERS):]

--- a/src/formpack/utils/ordered_collection.py
+++ b/src/formpack/utils/ordered_collection.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
-from collections import Counter, Callable
+from collections import Counter
+from collections.abc import Callable
 
 from .future import iteritems, OrderedDict
 from .string import orderable_with_none

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1794,6 +1794,83 @@ class TestFormPackExport(unittest.TestCase):
         zipped.close()
         raw_zip.close()
 
+    def test_select_multiple_summary(self):
+        title, schemas, submissions = build_fixture('dietary_needs')
+        fp = FormPack(schemas, title)
+        export = fp.export(
+            multiple_select='summary', versions=fp.versions.keys()
+        ).to_dict(submissions)
+        expected = OrderedDict([(
+            'Dietary needs',
+            {
+                'fields': ['restaurant_name', 'dietary_accommodations'],
+                'data': [
+                    ["Melba's", 'gluten_free'],
+                    ['Land of Kush', 'vegan vegetarian'],
+                    ['Sweet 27', 'gluten_free vegan vegetarian lactose_free'],
+                ],
+            },
+        )])
+        assert export == expected
+
+    def test_select_multiple_details(self):
+        title, schemas, submissions = build_fixture('dietary_needs')
+        fp = FormPack(schemas, title)
+        export = fp.export(
+            multiple_select='details', versions=fp.versions.keys()
+        ).to_dict(submissions)
+        expected = OrderedDict([(
+            'Dietary needs',
+            {
+                'fields': [
+                    'restaurant_name',
+                    'dietary_accommodations/gluten_free',
+                    'dietary_accommodations/vegan',
+                    'dietary_accommodations/vegetarian',
+                    'dietary_accommodations/lactose_free',
+                ],
+                'data': [
+                    ["Melba's", '1', '0', '0', '0'],
+                    ['Land of Kush', '0', '1', '1', '0'],
+                    ['Sweet 27', '1', '1', '1', '1'],
+                ],
+            },
+        )])
+        assert export == expected
+
+    def test_select_multiple_both(self):
+        title, schemas, submissions = build_fixture('dietary_needs')
+        fp = FormPack(schemas, title)
+        export = fp.export(
+            multiple_select='both', versions=fp.versions.keys()
+        ).to_dict(submissions)
+        expected = OrderedDict([(
+            'Dietary needs',
+            {
+                'fields': [
+                    'restaurant_name',
+                    'dietary_accommodations',
+                    'dietary_accommodations/gluten_free',
+                    'dietary_accommodations/vegan',
+                    'dietary_accommodations/vegetarian',
+                    'dietary_accommodations/lactose_free',
+                ],
+                'data': [
+                    ["Melba's", 'gluten_free', '1', '0', '0', '0'],
+                    ['Land of Kush', 'vegan vegetarian', '0', '1', '1', '0'],
+                    [
+                        'Sweet 27',
+                        'gluten_free vegan vegetarian lactose_free',
+                        '1',
+                        '1',
+                        '1',
+                        '1',
+                    ],
+                ],
+            },
+        )])
+        assert export == expected
+
     def test_select_multiple_with_different_options_in_multiple_versions(self):
         title, schemas, submissions = build_fixture('favorite_coffee')
         fp = FormPack(schemas, title)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1148,6 +1148,25 @@ class TestFormPackExport(unittest.TestCase):
         rows = list(fp.export(**options).to_csv(submissions))
         assert rows[1] == ('"#loc+name";"#indicator+diet";"";"";"";""')
 
+    def test_csv_with_tag_headers_select_multiple_summary_or_details(self):
+        """
+        The tag header row needs to change in accordance with the
+        `multiple_select` export option
+        """
+        title, schemas, submissions = build_fixture('dietary_needs')
+        fp = FormPack(schemas, title)
+        options = {'versions': 'dietv1', 'tag_cols_for_header': ['hxl']}
+
+        rows = list(
+            fp.export(multiple_select='summary', **options).to_csv(submissions)
+        )
+        assert rows[1] == ('"#loc+name";"#indicator+diet"')
+
+        rows = list(
+            fp.export(multiple_select='details', **options).to_csv(submissions)
+        )
+        assert rows[1] == ('"#loc+name";"#indicator+diet";"";"";""')
+
     # disabled for now
     # @raises(RuntimeError)
     # def test_csv_on_repeatable_groups(self):


### PR DESCRIPTION
Previously setting `multiple_select` to `summary` or `details` only affected the headers of exports; all the data rows always behaved as if it were set to `both`. This change fixes #234.

* Since formpack receives `multiple_select` only from the `Export()` constructor, set it as an instance attribute instead of passing it to various internal methods as an argument.
* Stop attempting to set up export-specific data structures in field class constructors, since fields are initialized before export options are known.
    * NB: This removes the `FormDataDef.value_names` and `FormField.empty_result` optimizations. I haven't noticed a performance decrease (yet).
* Delegate the handling of missing values to the `format()` method of field classes by passing `None` as the value.
    * Most fields return an empty cell for a `None` value, following the old behavior, but `FormChoiceFieldWithMultipleSelect` returns the appropriate number of empty cells based on `multiple_select` being set to `summary`, `details`, or `both`.
    * kobotoolbox/kpi#3083 updates the KPI tests to expect a missing `_submitted_by` value to export as an empty string instead of `None`.