### PR TITLE
Temporarily disable new media URL columns

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -420,6 +420,20 @@ class TextField(ExtendedFormField):
 
 
 class MediaField(TextField):
+    """
+    Stub to disable extra URL columns for now; see FutureMediaField
+    """
+    pass
+
+
+class FutureMediaField(TextField):
+    """
+    TODO: Remove the empty MediaField class above and rename this
+    FutureMediaField class to MediaField once we have a way to make the extra
+    columns optional.
+    Once that's done please uncomment/modify lines in
+    `tests.test_exports.TestFormPackExport.test_media_types()` as well.
+    """
 
     def get_labels(self, *args, **kwargs):
         label = self._get_label(*args, **kwargs)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -455,6 +455,10 @@ class TestFormPackExport(unittest.TestCase):
         self.assertEqual(export, expected_dict)
 
     def test_media_types(self):
+        """
+        Please uncomment the `…_URL` headers and corresponding data fields
+        after re-enabling `formpack.schema.fields.MediaField`
+        """
         title, schemas, submissions = build_fixture(
             'media_types'
         )
@@ -468,31 +472,31 @@ class TestFormPackExport(unittest.TestCase):
                     {
                         'fields': [
                             'audit',
-                            'audit_URL',
+                            # 'audit_URL',
                             'fav_emperor',
                             'image_of_emperor',
-                            'image_of_emperor_URL',
+                            # 'image_of_emperor_URL',
                             'another_image_of_emperor',
-                            'another_image_of_emperor_URL',
+                            # 'another_image_of_emperor_URL',
                         ],
                         'data': [
                             [
                                 'audit.csv',
-                                'https://kc.kobo.org/media/original?media_file=/path/to/audit.csv',
+                                # 'https://kc.kobo.org/media/original?media_file=/path/to/audit.csv',
                                 'julius',
                                 'julius.jpg',
-                                'https://kc.kobo.org/media/original?media_file=/path/to/julius.jpg',
+                                # 'https://kc.kobo.org/media/original?media_file=/path/to/julius.jpg',
                                 'another-julius.jpg',
-                                'https://kc.kobo.org/media/original?media_file=/path/to/another-julius.jpg',
+                                # 'https://kc.kobo.org/media/original?media_file=/path/to/another-julius.jpg',
                             ],
                             [
                                 'audit.csv',
-                                'https://kc.kobo.org/media/original?media_file=/path/to/audit.csv',
+                                # 'https://kc.kobo.org/media/original?media_file=/path/to/audit.csv',
                                 'augustus',
                                 'augustus.jpg',
-                                'https://kc.kobo.org/media/original?media_file=/path/to/augustus.jpg',
+                                # 'https://kc.kobo.org/media/original?media_file=/path/to/augustus.jpg',
                                 '',
-                                '',
+                                # '',
                             ],
                         ],
                     },

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -456,7 +456,7 @@ class TestFormPackExport(unittest.TestCase):
 
     def test_media_types(self):
         """
-        Please uncomment the `…_URL` headers and corresponding data fields
+        Please uncomment the `…_URL` fields and corresponding data values
         after re-enabling `formpack.schema.fields.MediaField`
         """
         title, schemas, submissions = build_fixture(


### PR DESCRIPTION
…so that columns remain consistent for existing workflows. This temporarily undoes the work in #258.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-KoBo-Dev/topic/links.20.2F.20URL.20to.20attachments.20in.20table