### PR TITLE
Fix translations and labels mismatch error message

### DIFF
--- a/tests/fixtures/translations_labels_mismatch/__init__.py
+++ b/tests/fixtures/translations_labels_mismatch/__init__.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+'''
+translations_labels_mismatch
+'''
+
+from ..load_fixture_json import load_fixture_json
+
+DATA = {
+    'title': 'Your favourite Roman emperors',
+    'id_string': 'translations_labels_mismatch',
+    'versions': [
+        load_fixture_json('translations_labels_mismatch/v1'),
+    ],
+}

--- a/tests/fixtures/translations_labels_mismatch/v1.json
+++ b/tests/fixtures/translations_labels_mismatch/v1.json
@@ -1,0 +1,27 @@
+{
+  "version": "v1",
+  "content": {
+    "survey": [
+      {
+        "type": "text",
+        "name": "fav_emperor",
+        "label": [
+            "Who is your favourite emperor?"
+        ],
+        "hint::English (en)": "Before the decline of the Roman Empire"
+      }
+    ],
+    "translated": [
+        "hint",
+        "label"
+    ],
+    "translations": [
+        null
+    ]
+  },
+  "submissions": [
+    {
+      "fav_emperor": "Marcus Aurelius"
+    }
+  ]
+}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -370,6 +370,12 @@ class TestFormPackExport(unittest.TestCase):
             ],
         )
 
+    def test_translations_labels_mismatch(self):
+        title, schemas, submissions = build_fixture('translations_labels_mismatch')
+        fp = FormPack(schemas, title)
+        options = {'versions': 'v1'}
+        export = fp.export(**options).to_dict(submissions)
+
     def test_simple_nested_grouped_repeatable(self):
         title, schemas, submissions = build_fixture(
             'simple_nested_grouped_repeatable'


### PR DESCRIPTION
## Description

Handle `None` type correctly and display error message correctly when there is a mismatch between the translations and labels.

## Related issues

closes #283 