### PR TITLE
Fix translations and labels mismatch error message

### DIFF
--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -28,7 +28,7 @@ class LabelStruct:
                 'Mismatched labels and translations: [{}] [{}] '
                 '{}!={}'.format(
                     ', '.join(labels),
-                    ', '.join(translations),
+                    ', '.join(map(str, translations)),
                     len(labels),
                     len(translations),
                 )

--- a/tests/fixtures/translations_labels_mismatch/__init__.py
+++ b/tests/fixtures/translations_labels_mismatch/__init__.py
@@ -1,0 +1,14 @@
+# coding: utf-8
+'''
+translations_labels_mismatch
+'''
+
+from ..load_fixture_json import load_fixture_json
+
+DATA = {
+    'title': 'Your favourite Roman emperors',
+    'id_string': 'translations_labels_mismatch',
+    'versions': [
+        load_fixture_json('translations_labels_mismatch/v1'),
+    ],
+}

--- a/tests/fixtures/translations_labels_mismatch/v1.json
+++ b/tests/fixtures/translations_labels_mismatch/v1.json
@@ -1,0 +1,27 @@
+{
+  "version": "v1",
+  "content": {
+    "survey": [
+      {
+        "type": "text",
+        "name": "fav_emperor",
+        "label": [
+            "Who is your favourite emperor?"
+        ],
+        "hint::English (en)": "Before the decline of the Roman Empire"
+      }
+    ],
+    "translated": [
+        "hint",
+        "label"
+    ],
+    "translations": [
+        null
+    ]
+  },
+  "submissions": [
+    {
+      "fav_emperor": "Marcus Aurelius"
+    }
+  ]
+}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -13,6 +13,7 @@ from path import TempDir
 
 from formpack import FormPack
 from formpack.constants import UNTRANSLATED
+from formpack.errors import TranslationError
 from formpack.schema.fields import (
     ValidationStatusCopyField,
     IdCopyField,
@@ -372,9 +373,8 @@ class TestFormPackExport(unittest.TestCase):
 
     def test_translations_labels_mismatch(self):
         title, schemas, submissions = build_fixture('translations_labels_mismatch')
-        fp = FormPack(schemas, title)
-        options = {'versions': 'v1'}
-        export = fp.export(**options).to_dict(submissions)
+        with self.assertRaises(TranslationError) as e:
+            fp = FormPack(schemas, title)
 
     def test_simple_nested_grouped_repeatable(self):
         title, schemas, submissions = build_fixture(

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -370,6 +370,12 @@ class TestFormPackExport(unittest.TestCase):
             ],
         )
 
+    def test_translations_labels_mismatch(self):
+        title, schemas, submissions = build_fixture('translations_labels_mismatch')
+        fp = FormPack(schemas, title)
+        options = {'versions': 'v1'}
+        export = fp.export(**options).to_dict(submissions)
+
     def test_simple_nested_grouped_repeatable(self):
         title, schemas, submissions = build_fixture(
             'simple_nested_grouped_repeatable'


### PR DESCRIPTION
This is a redo of #284 on top of #286, the squashed redo of #270.