### PR TITLE
Remove simserial and subscriberid from metadata

### DIFF
--- a/src/formpack/utils/replace_aliases.py
+++ b/src/formpack/utils/replace_aliases.py
@@ -103,14 +103,12 @@ META_TYPES = [
     'end',
     'deviceid',
     'phone_number',
-    'simserial',
     'audit',
     # meta values
     'username',
     # reconsider:
     'phonenumber',
     'imei',
-    'subscriberid',
     # geo
     'start-geopoint',
 ]


### PR DESCRIPTION
## Description

removed simserial and subscriberid from the meta data as Google no longer provides this information