### PR TITLE
Handle multiple spaces in or_other

### DIFF
--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -303,9 +303,9 @@ def _get_special_survey_cols(
 def _expand_type_to_dict(type_str: str) -> Dict[str, Union[str, bool]]:
     SELECT_PATTERN = r'^({select_type})\s+(\S+)$'
     out = {}
-    match = re.search('( or.other)$', type_str)
+    match = re.search('\s+(or.other)$', type_str)
     if match:
-        type_str = type_str.replace(match.groups()[0], '')
+        type_str = type_str.replace(match.groups()[0], '').strip()
         out[OR_OTHER_COLUMN] = True
     match = re.search('select_(one|multiple)(_or_other)', type_str)
     if match:

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -15,6 +15,7 @@ from formpack.utils.string import orderable_with_none
 
 def test_expand_selects_with_or_other():
     assert _expand_type_to_dict('select_one xx or other').get(_OR_OTHER) == True
+    assert _expand_type_to_dict('select_one   xx    or_other').get(_OR_OTHER) == True
     assert _expand_type_to_dict('select_one_or_other xx').get(_OR_OTHER) == True
     assert (
         _expand_type_to_dict('select_multiple_or_other xx').get(_OR_OTHER)
@@ -54,6 +55,14 @@ def test_expand_select_one_or_other():
     expand_content(s1, in_place=True)
     assert s1['survey'][0]['type'] == 'select_one'
     assert s1['survey'][0]['select_from_list_name'] == 'dogs'
+
+
+def test_expand_select_one_or_other_with_spaces():
+    s1 = {'survey': [{'type': 'select_one    dogs            or_other'}]}
+    expand_content(s1, in_place=True)
+    assert s1['survey'][0]['type'] == 'select_one'
+    assert s1['survey'][0]['select_from_list_name'] == 'dogs'
+    assert s1['survey'][0][_OR_OTHER] == True
 
 
 def test_expand_select_multiple():


### PR DESCRIPTION
## Description

Handle multiple spaces in select type questions between `list_name` and `or_other` option.

## Related issues

closes #303 