### PR TITLE
Allow a default value to be set for max-pixels on questions of type: "image"

### DIFF
--- a/src/formpack/pack.py
+++ b/src/formpack/pack.py
@@ -24,12 +24,14 @@ class FormPack:
         root_node_name='data',
         asset_type=None,
         submissions_xml=None,
+        default_image_max_pixels=None,
     ):
         """
         :param versions: list. Versions of the asset. It must be sorted in ascending order. From oldest to newest.
         :param title: string. The human readable name of the form.
         :param id_string: The human readable id of the form.
         :param default_version_id_key: string. The name of the field in submissions which stores the version ID
+        :param default_image_max_pixels: string. (numeric) When not None, questions type=image get assigned max-pixels parameter
         """
         # @TODO: Complete the signature for __init__
 
@@ -47,6 +49,7 @@ class FormPack:
 
         self.id_string = id_string
         self.root_node_name = root_node_name
+        self.default_image_max_pixels = default_image_max_pixels
 
         self.title = title
         self.strict_schema = strict_schema

--- a/src/formpack/utils/xlsform_parameters.py
+++ b/src/formpack/utils/xlsform_parameters.py
@@ -1,0 +1,24 @@
+'''
+parameters_string_to_dict:
+    - converts a string "key=val key2=val2" into a dict {'key': 'val', 'key2': 'val2'}
+parameters_dict_to_string:
+    - converts a dict {'key': 'val', 'k2': 'val'} into a string "key=val k2=val"
+'''
+import re
+
+
+def parameters_string_to_dict(params_str):
+    dd = {}
+    # print(params_str)
+    for param in re.split('\s+', params_str):
+        if '=' in param:
+            (key, val) = param.split('=')
+            dd[key] = val
+    return dd
+
+
+def parameters_dict_to_string(params_dict):
+    ps = []
+    for (key, val) in params_dict.items():
+        ps.append(f'{key}={val}')
+    return ' '.join(ps)

--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -18,6 +18,8 @@ from .errors import TranslationError
 from .schema import FormField, FormGroup, FormSection, FormChoice
 from .submission import FormSubmission
 from .utils import parse_xml_to_xmljson, normalize_data_type
+from .utils.xlsform_parameters import parameters_string_to_dict, parameters_dict_to_string
+
 from .utils.flatten_content import flatten_content
 from .utils.xform_tools import formversion_pyxform
 from .validators import validate_content
@@ -359,7 +361,18 @@ class FormVersion(BaseForm):
         )
 
     def to_dict(self, **opts):
-        return flatten_content(self.schema['content'], **opts)
+        content = flatten_content(self.schema['content'], **opts)
+        im_max_pixs = self.form_pack.default_image_max_pixels
+        if im_max_pixs is not None:
+            for row in content.get('survey'):
+                if row.get('type') == 'image':
+                    rparams = parameters_string_to_dict(row.get('parameters', ''))
+                    if rparams.get('max-pixels') == '-1':
+                        del rparams['max-pixels']
+                    elif 'max-pixels' not in rparams:
+                        rparams['max-pixels'] = str(im_max_pixs)
+                    row['parameters'] = parameters_dict_to_string(rparams)
+        return content
 
     # TODO: find where to move that
     def _load_submission_xml(self, xml):

--- a/tests/test_default_image_max_pixels.py
+++ b/tests/test_default_image_max_pixels.py
@@ -1,0 +1,110 @@
+'''
+FormPack object with
+    default_image_max_pixels=None does not touch 'max-pixels'
+    default_image_max_pixels=integer sets "parameters" column of questions of type == 'image'
+
+    To override default behavior and unset "max-pixels", set the value to -1 in the xlsform
+    See: https://xlsform.org/en/#image
+'''
+from formpack import FormPack
+from formpack.utils.xlsform_parameters import parameters_string_to_dict, parameters_dict_to_string
+
+
+# used in this test file
+def fp_content_with_row(rdata, **kwargs):
+    return FormPack([{'content': {'survey': [{
+        'name': 'q1', 'label': 'q1 label',
+        **rdata,
+    }]}, 'version': 'v1'}], 'title', 'idstr', **kwargs)
+
+
+# used in this test file
+def fp_content_with_row_to_xml(rdata, default_image_max_pixels):
+    return fp_content_with_row(rdata, default_image_max_pixels=default_image_max_pixels)[0].to_xml()
+
+#
+# Test micro utils:
+#  - parameters_string_to_dict
+#  - parameters_dict_to_string
+#
+def test_string_to_dict():
+    aa = parameters_string_to_dict('abc=123 def=456')
+    assert aa['abc'] == '123'
+    assert aa['def'] == '456'
+
+
+def test_dict_to_string():
+    assert parameters_dict_to_string({'abc': '987', 'def': '654'}) == 'abc=987 def=654'
+
+#
+# Test variations of FormPack(..., default_image_max_pixels=...).to_xml()
+#
+def test_has_max_pixels_set_00():
+    '''
+    if default not set
+    and row sets nothing
+    then no orx:max-pixels is in xform
+    '''
+    assert 'orx:max-pixels' not in \
+        fp_content_with_row_to_xml({
+            'type': 'image',
+        }, None)
+
+
+def test_has_max_pixels_set_01():
+    '''
+    if default is not set
+    and row sets 222
+    then 222 is in xform
+    '''
+    assert 'orx:max-pixels="222"' in \
+        fp_content_with_row_to_xml({
+            'type': 'image',
+            'parameters': 'max-pixels=222',
+        }, None)
+
+
+def test_has_max_pixels_set_10():
+    '''
+    if default is 111
+    and row sets nothing
+    then 111 is in xform
+    '''
+    assert 'orx:max-pixels="111"' in \
+        fp_content_with_row_to_xml({'type': 'image'}, '111')
+
+
+def test_has_max_pixels_set_11():
+    '''
+    if default is 111
+    and row sets value to 222
+    then 222 is in xform
+    '''
+    assert 'orx:max-pixels="222"' in \
+        fp_content_with_row_to_xml({
+            'type': 'image',
+            'parameters': 'max-pixels=222'
+        }, '111')
+
+
+def test_has_max_pixels_set_with_numeric_default():
+    '''
+    if default is 111 (int)
+    and row sets nothing
+    then "111" is in xform
+    '''
+    assert 'orx:max-pixels="111"' in \
+        fp_content_with_row_to_xml({'type': 'image'}, 111)
+
+
+def test_can_unset_default_with_negative1():
+    '''
+    if default is set to 111
+    and row sets -1
+    then no orx:max-pixels is in xform
+    '''
+    assert 'orx:max-pixels' not in \
+        fp_content_with_row_to_xml({
+            'type': 'image',
+            'parameters': 'max-pixels=-1',
+        }, 111)


### PR DESCRIPTION
This would go with a (yet to be created) KPI pull request to avoid deploying surveys collecting giant photos (Android default camera app photo sizes vary quite a bit, but generally larger than needed).

Closes issue #312 