### PR TITLE
expand select_*_from_file

### DIFF
--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -322,7 +322,10 @@ def _expand_type_to_dict(type_str: str) -> Dict[str, Union[str, bool]]:
             (type_, list_name) = match.groups()
             matched_type = selects[select_type]
             out['type'] = matched_type
-            out['select_from_list_name'] = list_name
+            ref_field_name = 'select_from_list_name'
+            if 'from_file' in matched_type:
+                ref_field_name = 'file'
+            out[ref_field_name] = list_name
             return out
     # if it does not expand, we return the original string
     return {'type': type_str}

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -28,6 +28,16 @@ def test_expand_selects_with_or_other():
     assert _expand_type_to_dict('select_one_or_other').get(_OR_OTHER) == True
 
 
+def test_expand_select_x_from_file():
+    row_type_dict = _expand_type_to_dict('select_one_from_file file.csv')
+    assert 'select_from_list_name' not in row_type_dict
+    assert row_type_dict.get('file') == 'file.csv'
+
+    row_type_dict = _expand_type_to_dict('select_multiple_from_file file.csv')
+    assert 'select_from_list_name' not in row_type_dict
+    assert row_type_dict.get('file') == 'file.csv'
+
+
 def test_expand_select_one():
     s1 = {'survey': [{'type': 'select_one dogs'}]}
     expand_content(s1, in_place=True)


### PR DESCRIPTION
select_multiple_from_file to reference
a file, rather than a remote list ID