### PR TITLE
Properly flatten select_one_from_file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,5 +4,8 @@ skip-string-normalization = true
 
 [tool.pytest.ini_options]
 markers = [
-    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    "slow: marks tests as slow (not executed by default - select with '-m \"slow\"')",
+]
+addopts = [
+    '-m not slow',
 ]

--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -251,3 +251,6 @@ def _flatten_survey_row(row):
                 row['type'] = '{} {} or_other'.format(_type, _list_name)
             else:
                 row['type'] = '{} {}'.format(_type, _list_name)
+        elif row['type'] == 'select_one_from_file' and 'file' in row:
+            _file = row.pop('file')
+            row['type'] = '{} {}'.format(_type, _file)

--- a/tests/test_utils_flatten_content.py
+++ b/tests/test_utils_flatten_content.py
@@ -107,6 +107,18 @@ def test_flatten_select_or_other():
     assert 'select_from_list_name' not in row0
 
 
+def test_flatten_select_one_from_file():
+    s1 = {
+        'survey': [
+            {'type': 'select_one_from_file', 'file': 'fruits.csv'}
+        ]
+    }
+    flatten_content(s1, in_place=True)
+    row0 = s1['survey'][0]
+    assert row0['type'] == 'select_one_from_file fruits.csv'
+    assert 'file' not in row0
+
+
 def test_flatten_select():
     s1 = {'survey': [{'type': 'select_one', 'select_from_list_name': 'aaa'}]}
     flatten_content(s1, in_place=True)


### PR DESCRIPTION
…to `select_one_from_file file.csv` instead of having `select_one_from_file` in the `type` column and `file.csv` in a nonstandard `file` column.

Fixes a problem introduced in https://github.com/kobotoolbox/formpack/pull/314

Reminder: update `formbuilder-misc` branch in KPI to require the new formpack commit hash once this is merged