### PR TITLE
Properly flatten select_multiple_from_file

### DIFF
--- a/src/formpack/utils/flatten_content.py
+++ b/src/formpack/utils/flatten_content.py
@@ -251,6 +251,9 @@ def _flatten_survey_row(row):
                 row['type'] = '{} {} or_other'.format(_type, _list_name)
             else:
                 row['type'] = '{} {}'.format(_type, _list_name)
-        elif row['type'] == 'select_one_from_file' and 'file' in row:
+        elif (
+            row['type'] in ('select_one_from_file', 'select_multiple_from_file')
+            and 'file' in row
+        ):
             _file = row.pop('file')
             row['type'] = '{} {}'.format(_type, _file)

--- a/tests/test_utils_flatten_content.py
+++ b/tests/test_utils_flatten_content.py
@@ -107,16 +107,17 @@ def test_flatten_select_or_other():
     assert 'select_from_list_name' not in row0
 
 
-def test_flatten_select_one_from_file():
-    s1 = {
-        'survey': [
-            {'type': 'select_one_from_file', 'file': 'fruits.csv'}
-        ]
-    }
-    flatten_content(s1, in_place=True)
-    row0 = s1['survey'][0]
-    assert row0['type'] == 'select_one_from_file fruits.csv'
-    assert 'file' not in row0
+def test_flatten_select_x_from_file():
+    for x in 'one', 'multiple':
+        s1 = {
+            'survey': [
+                {'type': f'select_{x}_from_file', 'file': 'fruits.csv'}
+            ]
+        }
+        flatten_content(s1, in_place=True)
+        row0 = s1['survey'][0]
+        assert row0['type'] == f'select_{x}_from_file fruits.csv'
+        assert 'file' not in row0
 
 
 def test_flatten_select():

--- a/tests/test_utils_flatten_content.py
+++ b/tests/test_utils_flatten_content.py
@@ -108,6 +108,7 @@ def test_flatten_select_or_other():
 
 
 def test_flatten_select_x_from_file():
+    # Search terms: select_one_from_file, select_multiple_from_file
     for x in 'one', 'multiple':
         s1 = {
             'survey': [


### PR DESCRIPTION
…to `select_multiple_from_file file.csv` instead of having `select_multiple_from_file` in the `type` column and `file.csv` in a nonstandard `file` column.

Fixes a problem introduced in #314, mistakenly left unaddressed in #318