### PR TITLE
Remove qpath, use (x)path instead

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -59,10 +59,6 @@ class FormField(FormDataDef):
         # do not include the root section in the path
         self.path = '/'.join(info.name for info in self.hierarchy[1:])
 
-    @property
-    def qpath(self):
-        return self.path.replace('/', '-')
-
     def get_labels(
         self,
         lang=UNSPECIFIED_TRANSLATION,
@@ -536,7 +532,7 @@ class QualField(TextField):
         name = self.name.split('/')[-1]
 
         try:
-            responses = entry['_supplementalDetails'][self.source_field.qpath][
+            responses = entry['_supplementalDetails'][self.source_field.path][
                 'qual'
             ]
         except KeyError:
@@ -626,7 +622,7 @@ class QualTranscriptField(QualField):
         name = self.name.split('/')[-1]
 
         try:
-            responses = entry['_supplementalDetails'][self.source_field.qpath]
+            responses = entry['_supplementalDetails'][self.source_field.path]
         except KeyError:
             return ''
 
@@ -653,7 +649,7 @@ class QualTranslationField(QualField):
         name = self.name.split('/')[-1]
 
         try:
-            responses = entry['_supplementalDetails'][self.source_field.qpath]
+            responses = entry['_supplementalDetails'][self.source_field.path]
         except KeyError:
             return ''
 

--- a/src/formpack/version.py
+++ b/src/formpack/version.py
@@ -129,7 +129,7 @@ class AnalysisForm(BaseForm):
         self, survey_field: FormField
     ) -> List[FormField]:
         _fields = []
-        for analysis_field in self.fields_by_source[survey_field.qpath]:
+        for analysis_field in self.fields_by_source[survey_field.path]:
             analysis_field.section = survey_field.section
             analysis_field.source_field = survey_field
             _fields.append(analysis_field)
@@ -141,7 +141,7 @@ class AnalysisForm(BaseForm):
         _fields = []
         for field in fields:
             _fields.append(field)
-            if field.qpath in self.fields_by_source:
+            if field.path in self.fields_by_source:
                 _fields += self._map_sections_to_analysis_fields(field)
         return _fields
 

--- a/tests/fixtures/analysis_form/analysis_form.json
+++ b/tests/fixtures/analysis_form/analysis_form.json
@@ -65,21 +65,21 @@
       "type": "qual_text",
       "name": "name_of_clerk/comment",
       "path": [
-        "clerk_details-name_of_clerk",
+        "clerk_details/name_of_clerk",
         "comment"
       ],
       "label": "Comment on the name of the clerk",
-      "source": "clerk_details-name_of_clerk"
+      "source": "clerk_details/name_of_clerk"
     },
     {
       "type": "qual_text",
       "name": "name_of_shop/comment",
       "path": [
-        "clerk_details-name_of_shop",
+        "clerk_details/name_of_shop",
         "comment"
       ],
       "label": "Comment on the name of the shop",
-      "source": "clerk_details-name_of_shop"
+      "source": "clerk_details/name_of_shop"
     }
   ],
   "translations": [

--- a/tests/fixtures/analysis_form/v1.json
+++ b/tests/fixtures/analysis_form/v1.json
@@ -63,7 +63,7 @@
             }
           }
         },
-        "clerk_details-name_of_clerk": {
+        "clerk_details/name_of_clerk": {
           "qual": [
             {
               "uuid": "comment",

--- a/tests/fixtures/analysis_form/v2.json
+++ b/tests/fixtures/analysis_form/v2.json
@@ -58,7 +58,7 @@
             "languageCode": "en"
           }
         },
-        "clerk_details-name_of_shop": {
+        "clerk_details/name_of_shop": {
           "qual": [
             {
               "uuid": "comment",

--- a/tests/fixtures/analysis_form_advanced/analysis_form.json
+++ b/tests/fixtures/analysis_form_advanced/analysis_form.json
@@ -9,10 +9,10 @@
       "type": "transcript",
       "name": "record_a_note/transcript_en",
       "path": [
-        "clerk_interactions-record_a_note",
+        "clerk_interactions/record_a_note",
         "transcript_en"
       ],
-      "source": "clerk_interactions-record_a_note",
+      "source": "clerk_interactions/record_a_note",
       "language": "en",
       "settings": {
         "mode": "auto",
@@ -23,7 +23,7 @@
       "type": "qual_select_multiple",
       "name": "record_a_note/tone_of_voice",
       "path": [
-        "clerk_interactions-record_a_note",
+        "clerk_interactions/record_a_note",
         "tone_of_voice"
       ],
       "label": "How was the tone of the clerk's voice?",
@@ -31,7 +31,7 @@
         "How was the tone of the clerk's voice?",
         "Kiel estis la tono de la voĉo de la oficisto?"
       ],
-      "source": "clerk_interactions-record_a_note",
+      "source": "clerk_interactions/record_a_note",
       "choices": [
         {
           "uuid": "anxious",
@@ -63,7 +63,7 @@
       "type": "qual_text",
       "name": "goods_sold/comment",
       "path": [
-        "clerk_interactions-goods_sold",
+        "clerk_interactions/goods_sold",
         "comment"
       ],
       "label": "Comment on the goods sold at the store",
@@ -71,13 +71,13 @@
         "Comment on the goods sold at the store",
         "Komentu la varojn venditajn en la vendejo"
       ],
-      "source": "clerk_interactions-goods_sold"
+      "source": "clerk_interactions/goods_sold"
     },
     {
       "type": "qual_select_one",
       "name": "goods_sold/rating",
       "path": [
-        "clerk_interactions-goods_sold",
+        "clerk_interactions/goods_sold",
         "rating"
       ],
       "label": "Rate the quality of the goods sold at the store",
@@ -85,7 +85,7 @@
         "Rate the quality of the goods sold at the store",
         "Komentu la varojn vendojn en la vendejo"
       ],
-      "source": "clerk_interactions-goods_sold",
+      "source": "clerk_interactions/goods_sold",
       "choices": [
         {
           "uuid": "1",

--- a/tests/fixtures/analysis_form_advanced/v1.json
+++ b/tests/fixtures/analysis_form_advanced/v1.json
@@ -78,7 +78,7 @@
         }
       ],
       "_supplementalDetails": {
-        "clerk_interactions-record_a_note": {
+        "clerk_interactions/record_a_note": {
           "transcript": {
             "value": "Hello how may I help you?",
             "languageCode": "en"
@@ -90,7 +90,7 @@
             }
           ]
         },
-        "clerk_interactions-goods_sold": {
+        "clerk_interactions/goods_sold": {
           "qual": [
             {"uuid": "comment", "val": "Not much diversity"},
             {"uuid": "rating", "val": {"uuid": "3"}}
@@ -108,7 +108,7 @@
         }
       ],
       "_supplementalDetails": {
-        "clerk_interactions-record_a_note": {
+        "clerk_interactions/record_a_note": {
           "transcript": {
             "value": "Thank you for your business",
             "languageCode": "en"
@@ -120,7 +120,7 @@
             }
           ]
         },
-        "clerk_interactions-goods_sold": {
+        "clerk_interactions/goods_sold": {
           "qual": [
             {"uuid": "rating", "val": {"uuid": "2"}}
           ]
@@ -137,7 +137,7 @@
         }
       ],
       "_supplementalDetails": {
-        "clerk_interactions-goods_sold": {
+        "clerk_interactions/goods_sold": {
           "qual": [
             {"uuid": "rating", "val": {"uuid": "3"}}
           ]


### PR DESCRIPTION
## Description 

Do not rely on dash to be a group delimiter. Remove deprecated `qpath` and uses (already) existing XPath instead.

## Related issues

Blocked by kobotoolbox/kpi#5091