### PR TITLE
feat: export `background-geopoint` as GPS field

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -241,6 +241,7 @@ class FormField(FormDataDef):
             # geo
             'geopoint': FormGPSField,
             'start-geopoint': FormGPSField,
+            'background-geopoint': FormGPSField,
             # media
             'video': MediaField,
             'image': MediaField,


### PR DESCRIPTION
Refer to https://github.com/kobotoolbox/kpi/pull/5238 for information about how to test `background-geopoint`.

Prior to this PR, `background-geopoint` questions are exported as if they were text; now, they're exported as GPS fields that are split across multiple columns for `_latitude`, `_longitude`, `_altitude`, and `_precision`.

I'm happy that the fallback behavior was exporting as text instead of crashing :)