### PR TITLE
Replace path.py with 2-line helper function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ requirements = [
     'begins',
     'jsonschema',
     'lxml',
-    'path.py',
     'pyquery',
     'pyxform',
     'statistics',

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,6 +1,9 @@
 # coding: utf-8
+import contextlib
 import io
 import json
+import pathlib
+import tempfile
 import unittest
 from collections import OrderedDict
 from dateutil import parser
@@ -10,7 +13,6 @@ from zipfile import ZipFile
 
 import openpyxl
 import pytest
-from path import TempDir
 
 from formpack import FormPack
 from formpack.constants import UNTRANSLATED
@@ -24,6 +26,13 @@ from .fixtures import build_fixture, open_fixture_file
 
 customer_satisfaction = build_fixture('customer_satisfaction')
 restaurant_profile = build_fixture('restaurant_profile')
+
+
+@contextlib.contextmanager
+def TempDir():
+    """ A small helper to avoid needing the entire path.py library """
+    with tempfile.TemporaryDirectory() as d:
+        yield pathlib.Path(d)
 
 
 class TestFormPackExport(unittest.TestCase):


### PR DESCRIPTION
To verify, follow the README to set up a virtual environment and run pytest. All tests should pass. The removed library was used only by unit tests.

Attention: if you receive `AttributeError: 'Survey' object has no attribute 'update'`, this is caused by breaking changes in pyxform 3.0.0. Run `pip install pyxform==2.2.0` and try again.

Internal discussion: https://chat.kobotoolbox.org/#narrow/stream/4-Kobo-Dev/topic/path.2C.20pathlib.2C.20path.2Epy