### PR TITLE
Update development dependencies to match kobotoolbox/kpi

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,14 +5,14 @@
 -e .
 
 # Install testing / development requirements
-coverage==6.3.2
+coverage[toml]==6.5.0
 coveralls==3.3.1
-flake8==4.0.1
+flake8==7.1.1
 funcsigs==1.0.2
-geojson-rewind==1.0.2
-openpyxl==3.0.9
-pytest-cov==3.0.0
-pytest==7.1.1
-python-dateutil==2.8.2
-tox==3.7.0
+geojson-rewind==1.1.0
+openpyxl==3.1.3
+pytest-cov==5.0.0
+pytest==8.1.1
+python-dateutil==2.9.0.post0
+tox==4.24.1
 xlrd==2.0.1


### PR DESCRIPTION
Because this is a library, dependencies (in setup.py) are unpinned, but development dependencies (for running pytest, etc.) *are* pinned. This updates those pinned dependencies to match what happens when this library is installed as a dependency of kpi.

To verify, follow the README to set up a virtual environment and run pytest. All tests should pass.

Attention: if you receive `AttributeError: 'Survey' object has no attribute 'update'`, this is caused by breaking changes in pyxform 3.0.0. Run `pip install pyxform==2.2.0` and try again.