### PR TITLE
fix: allow headers to be capitalized

### DIFF
--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -233,7 +233,7 @@ def _get_special_survey_cols(
     _pluck_uniq_cols('choices')
 
     for column_name in uniq_cols.keys():
-        if column_name in ['label', 'hint']:
+        if column_name.lower() in ['label', 'hint']:
             _mark_special(
                 column_name=column_name,
                 column=column_name,

--- a/tests/test_expand_content.py
+++ b/tests/test_expand_content.py
@@ -604,5 +604,11 @@ def test_expand_translations_null_lang():
     assert s1 == s1_copy
 
 
+def test_expand_ignores_case():
+    s1 = {'survey': [{'type': 'text', 'Label': 'hi'}]}
+    expand_content(s1, in_place=True)
+    assert s1.get('translated') == ['Label']
+
+
 def _s(rows):
     return {'survey': [dict([[key, 'x']]) for key in rows]}


### PR DESCRIPTION
## Summary
Allow capitalization of the 'label' and 'name' headers in an xls upload.

## Notes
When an XLSForm is uploaded with capital letters in the label or name headers, interpret it the same as their lowercase counterparts. This fixes a `ValueError` on deploy, which was happening because the import didn't recognize the label column as one that doesn't expect translations.

## Preview
Note: when switching between main and this branch in the formpack code, make sure to run `pip-compile` and `pip install` again.
1. clone this repo into your local copy of kpi
2. update kpi's requirements.in to use -e /container/path/to/kpi/formpack instead of the git address currently there
3. `pip-compile dependencies/pip/requirements.in && pip-compile dependencies/pip/dev_requirements.in`
4. `pip install -r dependencies/pip/dev_requirements.txt`
5. Create a project in kpi by uploading this form 
[SimpleForm-copy.xlsx](https://github.com/user-attachments/files/18607424/SimpleForm-copy.xlsx)
6. Deploy the project
7. :red_circle: [on main] Error. If you have debug mode on, it will say `ValueError: "Label" column is not translated`
8. :green_circle: [on branch] Project deploys successfully