### PR TITLE
feat: Set `{field}_URL` to `Deleted` for attachments marked as deleted

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -685,17 +685,19 @@ class MediaField(TextField):
     ):
         if val is None:
             val = ''
+        attachment = attachment[0] if attachment else {}
+        is_deleted = attachment.get('is_deleted', False)
 
-        if not include_media_url:
-            return {self.name: val}
-
-        download_url = (
-            attachment[0].get('download_url', '') if attachment else ''
-        )
-        return {
-            self.name: val,
-            f'{self.name}_URL': download_url,
+        result = {
+            self.name: val
         }
+
+        if include_media_url:
+            download_url = attachment.get('download_url', '')
+            result[f'{self.name}_URL'] = (
+                download_url if not is_deleted else 'Deleted'
+            )
+        return result
 
 
 class AuditField(MediaField):

--- a/tests/fixtures/media_types/v1.json
+++ b/tests/fixtures/media_types/v1.json
@@ -85,6 +85,25 @@
             "filename": "/path/to/audit.csv"
           }
       ]
+    },
+    {
+      "fav_emperor": "tiberius",
+      "image_of_emperor": "tiberius.jpg",
+      "another_image_of_emperor": "",
+      "meta/audit": "audit.csv",
+      "meta/versionID": "romev1",
+      "meta/instanceID": "uuid:40805f86-2638-46f1-ab5a-72f4632474b7",
+      "_attachments": [
+        {
+          "download_url": "https://kc.kobo.org/media/original?media_file=/path/to/tiberius.jpg",
+          "filename": "/path/to/tiberius.jpg",
+          "is_deleted": true
+        },
+        {
+          "download_url": "https://kc.kobo.org/media/original?media_file=/path/to/audit.csv",
+          "filename": "/path/to/audit.csv"
+        }
+      ]
     }
   ]
 }

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -703,6 +703,15 @@ class TestFormPackExport(unittest.TestCase):
                                 '',
                                 '',
                             ],
+                            [
+                                'audit.csv',
+                                'https://kc.kobo.org/media/original?media_file=/path/to/audit.csv',
+                                'tiberius',
+                                'tiberius.jpg',
+                                'Deleted',
+                                '',
+                                '',
+                            ]
                         ],
                     },
                 )
@@ -739,6 +748,12 @@ class TestFormPackExport(unittest.TestCase):
                                 'augustus.jpg',
                                 '',
                             ],
+                            [
+                                'audit.csv',
+                                'tiberius',
+                                'tiberius.jpg',
+                                '',
+                            ]
                         ],
                     },
                 )


### PR DESCRIPTION
### Summary

Set `{field}_URL` to 'Deleted' for deleted attachments, when `include_media_url` is True.

### Description

- Updated the logic to set `{field}_URL` to 'Deleted' if the attachment is marked as deleted and `include_media_url` is True.
- Updated the test fixture to include submissions with deleted attachments and extended unit tests to verify the correct behavior of `{field}_URL` field.
