### PR TITLE
fix(autoreport): treat non-finite decimal values as not_provided DEV-1797

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -922,7 +922,10 @@ class NumField(FormField):
         if self.data_type == 'integer':
             yield int(raw_values)
         else:
-            yield float(raw_values)
+            value = float(raw_values)
+            if not math.isfinite(value):
+                raise ValueError(f'Non-finite float value: {raw_values!r}')
+            yield value
 
     def format(self, val, xls_types_as_text=True, *args, **kwargs):
         if val is None:

--- a/tests/test_autoreport.py
+++ b/tests/test_autoreport.py
@@ -647,3 +647,57 @@ class TestAutoReport(unittest.TestCase):
         ]
         for i, stat in enumerate(stats):
             assert stat == expected[i]
+
+    def test_stats_with_non_finite_float_value(self):
+        """
+        Non-finite float values (Inf, -Inf, nan) for a decimal field should
+        be treated as if no response was provided (not_provided).
+        """
+        title = 'Just one decimal'
+        schemas = [
+            {
+                'content': {
+                    'survey': [
+                        {
+                            'type': 'decimal',
+                            'name': 'the_number',
+                            'label': 'Enter the number!',
+                        }
+                    ]
+                }
+            }
+        ]
+        submissions = [
+            {'the_number': '1.0'},
+            {'the_number': '2.0'},
+            {'the_number': '3.0'},
+            {'the_number': 'Inf'},
+            {'the_number': '-Inf'},
+            {'the_number': 'nan'},
+        ]
+        fp = FormPack(schemas, title)
+
+        report = fp.autoreport()
+        stats = report.get_stats(submissions)
+
+        assert stats.submissions_count == len(submissions)
+
+        stats = [(str(repr(f)), n, d) for f, n, d in stats]
+        expected = [
+            (
+                "<NumField name='the_number' type='decimal'>",
+                'the_number',
+                {
+                    'mean': 2.0,
+                    'median': 2.0,
+                    'mode': '*',
+                    'not_provided': 3,
+                    'provided': 3,
+                    'show_graph': False,
+                    'stdev': 1.0,
+                    'total_count': 6,
+                },
+            )
+        ]
+        for i, stat in enumerate(stats):
+            assert stat == expected[i]


### PR DESCRIPTION
## What was done
- `NumField.parse_values` now raises a `ValueError` when a `decimal` field yields a non-finite float (`Inf`, `-Inf`, `nan`)
- The existing `ValueError` handling in `_calculate_stats` already treats these as blank responses, incrementing `not_provided` without affecting `provided` or `total_count`

## Why
Non-finite float values (`Inf`, `-Inf`, `nan`) can appear in submissions (e.g. from buggy clients or division-by-zero in calculated fields). Previously these were passed through silently, corrupting statistics (`mean`, `median`, etc.) and inflating `provided`/`total_count`.

## Testing
- Added `test_stats_with_non_finite_float_value` in `tests/test_autoreport.py` covering `Inf`, `-Inf`, and `nan` values for a `decimal` field
- Verified that `not_provided` increments correctly and that `provided`/`total_count` remain accurate