### PR TITLE
fix: use raw string for regex in xlsform_parameters

### DIFF
--- a/.github/workflows/pytest-with-coveralls.yml
+++ b/.github/workflows/pytest-with-coveralls.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.12']
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ env.source
 *sublime-*
 .vscode/
 .idea/
+.claude/

--- a/src/formpack/utils/xlsform_parameters.py
+++ b/src/formpack/utils/xlsform_parameters.py
@@ -10,7 +10,7 @@ import re
 def parameters_string_to_dict(params_str):
     dd = {}
     # print(params_str)
-    for param in re.split('\s+', params_str):
+    for param in re.split(r'\s+', params_str):
         if '=' in param:
             (key, val) = param.split('=')
             dd[key] = val


### PR DESCRIPTION
## Summary
Python 3.12 raises a `SyntaxWarning` when running tests due to an invalid escape sequence in a regex string.

## Notes
- `re.split('\s+', ...)` → `re.split(r'\s+', ...)` in `xlsform_parameters.py`
- `SyntaxWarning` is emitted at compile time; only visible on fresh installs (no `.pyc` cache), hence surfacing in CI but not locally