### PR TITLE
fix: suppress xlsxwriter URL warning when writing cells DEV-2020

### DIFF
--- a/src/formpack/reporting/export.py
+++ b/src/formpack/reporting/export.py
@@ -817,14 +817,7 @@ class Export:
             for col_index, cell_value in enumerate(data):
                 # Call `write()` directly to facilitate error handling (as
                 # opposed to `write_row()`)
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        'ignore',
-                        message='Ignoring URL',
-                        category=UserWarning,
-                        module='xlsxwriter',
-                    )
-                    error = sheet_.write(row_index, col_index, cell_value)
+                error = sheet_.write(row_index, col_index, cell_value)
                 if error == 0:
                     continue
                 else:
@@ -853,32 +846,41 @@ class Export:
             row_index += 1
             sheet_row_positions[sheet_] = row_index
 
-        for chunk in self.parse_submissions(submissions):
-            for section_name, rows in chunk.items():
-                try:
-                    sheet_name = sheet_name_mapping[section_name]
-                except KeyError:
-                    sheet_name = unique_name_for_xls(
-                        section_name, sheet_name_mapping.values()
-                    )
-                    sheet_name_mapping[section_name] = sheet_name
-                try:
-                    current_sheet = sheets[sheet_name]
-                except KeyError:
-                    current_sheet = workbook.add_worksheet(sheet_name)
-                    sheets[sheet_name] = current_sheet
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'ignore',
+                message='Ignoring URL',
+                category=UserWarning,
+                module='xlsxwriter',
+            )
+            for chunk in self.parse_submissions(submissions):
+                for section_name, rows in chunk.items():
+                    try:
+                        sheet_name = sheet_name_mapping[section_name]
+                    except KeyError:
+                        sheet_name = unique_name_for_xls(
+                            section_name, sheet_name_mapping.values()
+                        )
+                        sheet_name_mapping[section_name] = sheet_name
+                    try:
+                        current_sheet = sheets[sheet_name]
+                    except KeyError:
+                        current_sheet = workbook.add_worksheet(sheet_name)
+                        sheets[sheet_name] = current_sheet
 
-                    _append_row_to_sheet(
-                        current_sheet, self.labels[section_name]
-                    )
+                        _append_row_to_sheet(
+                            current_sheet, self.labels[section_name]
+                        )
 
-                    # Include specified tag columns as extra header rows
-                    tag_rows = self.get_header_rows_for_tag_cols(section_name)
-                    for tag_row in tag_rows:
-                        _append_row_to_sheet(current_sheet, tag_row)
+                        # Include specified tag columns as extra header rows
+                        tag_rows = self.get_header_rows_for_tag_cols(
+                            section_name
+                        )
+                        for tag_row in tag_rows:
+                            _append_row_to_sheet(current_sheet, tag_row)
 
-                for row in rows:
-                    _append_row_to_sheet(current_sheet, row)
+                    for row in rows:
+                        _append_row_to_sheet(current_sheet, row)
 
         workbook.close()
 

--- a/src/formpack/reporting/export.py
+++ b/src/formpack/reporting/export.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 import json
 import re
+import warnings
 import zipfile
 from collections import defaultdict, OrderedDict
 from inspect import isclass
@@ -816,7 +817,14 @@ class Export:
             for col_index, cell_value in enumerate(data):
                 # Call `write()` directly to facilitate error handling (as
                 # opposed to `write_row()`)
-                error = sheet_.write(row_index, col_index, cell_value)
+                with warnings.catch_warnings():
+                    warnings.filterwarnings(
+                        'ignore',
+                        message='Ignoring URL',
+                        category=UserWarning,
+                        module='xlsxwriter',
+                    )
+                    error = sheet_.write(row_index, col_index, cell_value)
                 if error == 0:
                     continue
                 else:

--- a/src/formpack/utils/xlsform_parameters.py
+++ b/src/formpack/utils/xlsform_parameters.py
@@ -10,7 +10,7 @@ import re
 def parameters_string_to_dict(params_str):
     dd = {}
     # print(params_str)
-    for param in re.split('\s+', params_str):
+    for param in re.split(r'\s+', params_str):
         if '=' in param:
             (key, val) = param.split('=')
             dd[key] = val

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -2,6 +2,7 @@
 import contextlib
 import io
 import json
+import warnings
 import pathlib
 import tempfile
 import unittest
@@ -2068,7 +2069,14 @@ class TestFormPackExport(unittest.TestCase):
         fp = FormPack(schemas, title)
         # Faster than writing to a file, but still takes about 5 seconds
         temporary_xlsx = io.BytesIO()
-        fp.export().to_xlsx(temporary_xlsx, submissions)
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                'error',
+                message='Ignoring URL',
+                category=UserWarning,
+                module='xlsxwriter',
+            )
+            fp.export().to_xlsx(temporary_xlsx, submissions)
         book = openpyxl.load_workbook(temporary_xlsx, read_only=True)
         sheet = book[title]
         row_values = [cell.value for cell in sheet[len(submissions) + 1]]


### PR DESCRIPTION
## Summary
xlsxwriter emitted a `UserWarning` when writing a cell containing a URL that exceeds its internal limits (too long or too many URLs in the sheet), even when the code already handles those cases gracefully by falling back to plain-string writing.

## Notes
- `warnings.catch_warnings()` + `filterwarnings('ignore', message='Ignoring URL', ...)` wraps each `sheet_.write()` call in `Export._append_row_to_sheet`
- The fallback to `write_string()` on non-zero return code is unchanged
- Both `test_xlsx_too_many_urls` now assert the warning is **not** raised (via `filterwarnings('error', ...)`)

## Preview steps
- Run `pytest tests/test_exports.py::TestFormPackExport::test_xlsx_too_many_urls -m slow` — should pass with no warnings
- Comment [lines](https://github.com/kobotoolbox/formpack/pull/346/changes#diff-c960a2dd6ed9ad6775416e4a60b6ad56e12958e65ec52e4f6775d1ab9ea580d4R820-R827), the test should not pass