### PR TITLE
Add unit tests for geopoint exports

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -65,6 +65,64 @@ class TestFormPackExport(unittest.TestCase):
 
         self.assertEqual(export, expected)
 
+    def test_geopoint_types_export_to_component_columns(self):
+        expected_fields = [
+            'location',
+            '_location_latitude',
+            '_location_longitude',
+            '_location_altitude',
+            '_location_precision',
+        ]
+        submissions = [
+            {
+                '__version__': 'v1',
+                '_uuid': 'complete-geopoint',
+                'location': '12.34 -23.45 100.5 4.2',
+            },
+            {
+                '__version__': 'v1',
+                '_uuid': 'two-dimensional-geopoint',
+                'location': '13.42 -25.43',
+            },
+            {
+                '__version__': 'v1',
+                '_uuid': 'missing-geopoint',
+                'location': None,
+            },
+        ]
+        expected_data = [
+            ['12.34 -23.45 100.5 4.2', '12.34', '-23.45', '100.5', '4.2'],
+            ['13.42 -25.43', '13.42', '-25.43', '', ''],
+            ['', '', '', '', ''],
+        ]
+
+        for field_type in (
+            'geopoint',
+            'start-geopoint',
+            'background-geopoint',
+        ):
+            with self.subTest(field_type=field_type):
+                schema = {
+                    'id_string': 'geo',
+                    'version': 'v1',
+                    'version_id_key': '__version__',
+                    'content': {
+                        'survey': [
+                            {
+                                'type': field_type,
+                                'name': 'location',
+                                'label': 'Location',
+                            }
+                        ]
+                    },
+                }
+                export = FormPack([schema], 'Geo').export().to_dict(
+                    submissions
+                )['Geo']
+
+                self.assertEqual(export['fields'], expected_fields)
+                self.assertEqual(export['data'], expected_data)
+
     def test_generator_export_labels_without_translations(self):
 
         title, schemas, submissions = customer_satisfaction


### PR DESCRIPTION
## What changed

- adds export coverage for `geopoint`, `start-geopoint`, and `background-geopoint`
- verifies the conventional `_latitude`, `_longitude`, `_altitude`, and `_precision` columns
- covers complete four-component values, two-dimensional values, and missing values

## Why

These three field types are mapped to `FormGPSField`, but their component-column export behavior was not directly covered together. The tests document and protect the expected export contract for downstream survey-data consumers.

## Validation

- `python -m pytest -q tests/test_exports.py` — 72 passed, 1 deselected, 3 subtests passed
- `git diff --check`

Closes #328
