### PR TITLE
fix(supplementalDetails): tolerate missing 'value' in NLP results DEV-2508

### DIFF
--- a/src/formpack/schema/fields.py
+++ b/src/formpack/schema/fields.py
@@ -549,7 +549,9 @@ class QualField(TextField):
             return ''
 
         if question_response := responses.get(field_uuid):
-            return question_response['value']
+            # `value` is absent when the response only carries a `verified`
+            # flag, and when a result is awaiting review
+            return question_response.get('value', '')
 
         return ''
 
@@ -713,8 +715,10 @@ class QualNameSplittingTransxField(QualField):
         # A transcript does not have a dictionary with language keys:
         #     {'transcript': {'languageCode': 'en', 'value': 'i am a raisin'}}
         if responses.get('languageCode') == self.language:
-            # Grab the value directly
-            return responses['value']
+            # Grab the value directly. `value` is absent while the result is
+            # awaiting review:
+            #     {'transcript': {'languageCode': 'en', 'pendingReview': True}}
+            return responses.get('value', '')
 
         # However, translations do have an outer dictionary with language keys:
         #     {

--- a/tests/test_additional_field_exports.py
+++ b/tests/test_additional_field_exports.py
@@ -1,5 +1,7 @@
 # coding: utf-8
 import unittest
+from copy import deepcopy
+
 from formpack import FormPack
 from .fixtures import build_fixture
 from .fixtures.load_fixture_json import load_analysis_form_json
@@ -518,6 +520,81 @@ def test_additional_field_exports_all_versions_langs():
         'name_of_clerk',
         'name_of_clerk - Comment on the name of the clerk',
     ]
+
+
+def test_transcript_pending_review_exports_as_blank():
+    """
+    KPI omits `value` from a transcript that has been generated but not yet
+    accepted, sending `pendingReview` instead. Such a transcript must export
+    as an empty string rather than raising `KeyError`
+    """
+    title, schemas, submissions = build_fixture('analysis_form')
+    analysis_form = load_analysis_form_json('analysis_form')
+    pack = FormPack(schemas, title=title)
+    pack.extend_survey(analysis_form)
+
+    submissions = deepcopy(submissions)
+    submissions[0]['_supplementalDetails']['record_a_note']['transcript'] = {
+        'languageCode': 'es',
+        'regionCode': None,
+        'pendingReview': True,
+    }
+
+    options = {
+        'versions': 'v1',
+        'filter_fields': [
+            'record_a_note',
+            '_supplementalDetails/record_a_note/transcript_en',
+            '_supplementalDetails/record_a_note/transcript_es',
+            '_supplementalDetails/record_a_note/translation_en',
+            '_supplementalDetails/record_a_note/translation_es',
+        ],
+    }
+    export = pack.export(**options)
+    values = export.to_dict(submissions)
+    main_export_sheet = values['Simple Clerk Interaction']
+
+    response0 = main_export_sheet['data'][0]
+    assert response0 == [
+        'clerk_interaction_1.mp3',
+        '',
+        '',
+        'Hello how may I help you?',
+        '',
+    ]
+
+
+def test_qual_response_without_value_exports_as_blank():
+    """
+    A qualitative analysis response may legitimately carry only a `verified`
+    flag, with no `value`
+    """
+    title, schemas, submissions = build_fixture('analysis_form')
+    analysis_form = load_analysis_form_json('analysis_form')
+    pack = FormPack(schemas, title=title)
+    pack.extend_survey(analysis_form)
+
+    submissions = deepcopy(submissions)
+    supplement = submissions[0]['_supplementalDetails']
+    supplement['clerk_details/name_of_clerk']['qual']['uuid_for_comment'] = {
+        'uuid': 'uuid_for_comment',
+        'verified': True,
+    }
+
+    qual_field = 'clerk_details/name_of_clerk/uuid_for_comment'
+    options = {
+        'versions': 'v1',
+        'filter_fields': [
+            'clerk_details/name_of_clerk',
+            f'_supplementalDetails/{qual_field}',
+        ],
+    }
+    export = pack.export(**options)
+    values = export.to_dict(submissions)
+    main_export_sheet = values['Simple Clerk Interaction']
+
+    response0 = main_export_sheet['data'][0]
+    assert response0 == ['John', '']
 
 
 def test_simple_report_with_analysis_form():

--- a/tests/test_additional_field_exports.py
+++ b/tests/test_additional_field_exports.py
@@ -524,9 +524,10 @@ def test_additional_field_exports_all_versions_langs():
 
 def test_transcript_pending_review_exports_as_blank():
     """
-    KPI omits `value` from a transcript that has been generated but not yet
-    accepted, sending `pendingReview` instead. Such a transcript must export
-    as an empty string rather than raising `KeyError`
+    Before kobotoolbox/kpi#7344, KPI omitted `value` from a transcript that
+    had been generated but not yet accepted, sending `pendingReview` instead.
+    formpack must still tolerate that shape and export such a transcript as an
+    empty string rather than raising `KeyError`
     """
     title, schemas, submissions = build_fixture('analysis_form')
     analysis_form = load_analysis_form_json('analysis_form')


### PR DESCRIPTION
### 📣 Summary

Downloading data as XLS or CSV no longer fails on projects that have an automatic transcription still waiting to be reviewed.

### 📖 Description

If a project had a transcription that had been generated but not yet accepted, every XLS and CSV download of that project failed with a generic "Export Failed" message. Downloads now work again, and a transcription that hasn't been accepted yet is left blank in the file, as it was before.

### 💭 Notes

- kpi DEV-2333 started emitting `{'languageCode': …, 'pendingReview': True}` with no `value` key. `QualNameSplittingTransxField` branched on `languageCode` and then read `responses['value']` unguarded, so a single un-accepted transcript killed the whole export.
- The translation branch a few lines below already swallowed that `KeyError` and returned `''`; this just makes the transcript branch consistent with it.
- `QualField` gets the same guard: a qual response may legitimately hold only `verified` and no `value` (kpi's `qualCommon` `oneOf`). Not reachable through kpi's current output transform — defensive only.
- ⚠️ This restores pre-DEV-2333 behaviour, where an un-accepted result exports blank. If exports should instead *include* the un-reviewed text, the fix belongs in kpi (`subsequences/actions/mixins.py`) rather than here — hence draft.
- Needs a follow-up kpi PR bumping the `formpack` pin.

### 👀 Preview steps

1. ℹ️ `pip install -r dev-requirements.txt`
2. run `pytest tests/test_additional_field_exports.py`
3. 🔴 [on main] `test_transcript_pending_review_exports_as_blank` and `test_qual_response_without_value_exports_as_blank` fail with `KeyError: 'value'`, at `fields.py:717` and `fields.py:552`
4. 🟢 [on PR] full suite passes — 255 passed, 2 skipped
