### PR TITLE
refactor(constants): export compiled XLSForm column and version regexes DEV-2656

### DIFF
--- a/src/formpack/constants.py
+++ b/src/formpack/constants.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+import re
 
 # In the core formpack code, the default `lang` parameter conflicted
 # with the desired representation of the JSON form, where "null" would
@@ -58,6 +59,26 @@ TAG_COLUMNS_AND_SEPARATORS = {
 #     …
 #     Media is translatable in the same way as labels and hints…
 MEDIA_COLUMN_NAMES = ('audio', 'image', 'video', 'big-image')
+
+# Compiled patterns describing XLSForm column headers, kept here so other
+# consumers (e.g. kpi's import validation) rely on the exact same rules as
+# `formpack.utils.expand_content._get_special_survey_cols()`. Separators are
+# one or two colons with optional surrounding whitespace.
+_MEDIA_NAMES = '|'.join(MEDIA_COLUMN_NAMES)
+# translated media column, e.g. `image::English (en)`, `media::image::Français`
+MEDIA_COLUMN_WITH_LANG_RE = re.compile(
+    rf'^(media\s*::?\s*)?({_MEDIA_NAMES})\s*::?\s*([^:]+)$'
+)
+# untranslated media column, e.g. `image`, `media::image`
+MEDIA_COLUMN_RE = re.compile(rf'^(media\s*::?\s*)?({_MEDIA_NAMES})$')
+# any other translated column, e.g. `label::English (en)`, `hint::Français`
+TRANSLATED_COLUMN_RE = re.compile(r'^([^:]+)\s*::?\s*([^:]+)$')
+
+# Submission fields that store the form version id, possibly mangled,
+# e.g. `__version__`, `_version_`, `_version__001`
+FUZZY_VERSION_ID_KEY = '_version_'
+INFERRED_VERSION_ID_KEY = '__inferred_version__'
+FUZZY_VERSION_RE = re.compile(r'^__?version__?(\d{3})?$')
 
 # Export Settings
 EXPORT_SETTING_FIELDS = 'fields'

--- a/src/formpack/utils/expand_content.py
+++ b/src/formpack/utils/expand_content.py
@@ -21,8 +21,11 @@ from .iterator import get_first_occurrence
 from .replace_aliases import META_TYPES, selects
 from ..constants import (
     MEDIA_COLUMN_NAMES,
+    MEDIA_COLUMN_RE,
+    MEDIA_COLUMN_WITH_LANG_RE,
     OR_OTHER_COLUMN,
     TAG_COLUMNS_AND_SEPARATORS,
+    TRANSLATED_COLUMN_RE,
     UNTRANSLATED,
 )
 
@@ -208,8 +211,6 @@ def _get_special_survey_cols(
         'hint::English',
     For more examples, see tests.
     """
-    RE_MEDIA_COLUMN_NAMES = '|'.join(MEDIA_COLUMN_NAMES)
-
     uniq_cols = OrderedDict()
     special = OrderedDict()
 
@@ -245,10 +246,7 @@ def _get_special_survey_cols(
             continue
         if column_name.startswith('body:'):
             continue
-        mtch = re.match(
-            rf'^(media\s*::?\s*)?({RE_MEDIA_COLUMN_NAMES})\s*::?\s*([^:]+)$',
-            column_name,
-        )
+        mtch = MEDIA_COLUMN_WITH_LANG_RE.match(column_name)
         if mtch:
             matched = mtch.groups()
             media_type = matched[1]
@@ -261,9 +259,7 @@ def _get_special_survey_cols(
                 translation=translation,
             )
             continue
-        mtch = re.match(
-            rf'^(media\s*::?\s*)?({RE_MEDIA_COLUMN_NAMES})$', column_name
-        )
+        mtch = MEDIA_COLUMN_RE.match(column_name)
         if mtch:
             matched = mtch.groups()
             media_type = matched[1]
@@ -275,7 +271,7 @@ def _get_special_survey_cols(
                 translation=UNTRANSLATED,
             )
             continue
-        mtch = re.match(r'^([^:]+)\s*::?\s*([^:]+)$', column_name)
+        mtch = TRANSLATED_COLUMN_RE.match(column_name)
         if mtch:
             # example: label::x, constraint_message::x, hint::x
             matched = mtch.groups()

--- a/tests/test_big_image_media_handling.py
+++ b/tests/test_big_image_media_handling.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 
 from formpack import FormPack
@@ -60,10 +62,20 @@ def test_formpack_raises_error_when_big_image_not_in_media_names(monkeypatch):
         'translations': [None],
     }
 
-    # Patch MEDIA_COLUMN_NAMES to exclude 'big-image'
+    # Patch MEDIA_COLUMN_NAMES, and the patterns compiled from it in
+    # formpack.constants, to exclude 'big-image'
+    media_names = ('image', 'audio', 'video')
+    media_re = '|'.join(media_names)
     monkeypatch.setattr(
-        'formpack.utils.expand_content.MEDIA_COLUMN_NAMES',
-        ('image', 'audio', 'video')
+        'formpack.utils.expand_content.MEDIA_COLUMN_NAMES', media_names
+    )
+    monkeypatch.setattr(
+        'formpack.utils.expand_content.MEDIA_COLUMN_WITH_LANG_RE',
+        re.compile(rf'^(media\s*::?\s*)?({media_re})\s*::?\s*([^:]+)$'),
+    )
+    monkeypatch.setattr(
+        'formpack.utils.expand_content.MEDIA_COLUMN_RE',
+        re.compile(rf'^(media\s*::?\s*)?({media_re})$'),
     )
     expand_content(content, in_place=True)
 


### PR DESCRIPTION
### 📣 Summary

Internal refactor, no behavior change: the regexes describing XLSForm column headers and fuzzy version keys become compiled, documented constants in `formpack.constants`.

### 💭 Notes

- New exports: `MEDIA_COLUMN_WITH_LANG_RE`, `MEDIA_COLUMN_RE`, `TRANSLATED_COLUMN_RE` (moved out of `_get_special_survey_cols()`, which now uses them), plus `FUZZY_VERSION_RE`/`FUZZY_VERSION_ID_KEY`/`INFERRED_VERSION_ID_KEY` so kpi's `kobo/apps/reports/constants.py` copies can be dropped in a follow-up.
- `test_formpack_raises_error_when_big_image_not_in_media_names` monkeypatched `MEDIA_COLUMN_NAMES`; it now patches the compiled patterns too, since they are bound at import time.

### 👀 Preview steps

Behavior can't change: full test suite passes (255 passed, 2 skipped), and the patterns are byte-for-byte the ones previously built inline.